### PR TITLE
Remove verbosity argument in LRScheduler

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -90,7 +90,6 @@ class WarmupCosineLRScheduler(LRScheduler):
         max_epochs,
         cosine_final: float = 0.001,
         last_epoch=-1,
-        verbose=False,
     ):
         """Use cosine_final to switch on/off the cosine annealing.
 
@@ -100,7 +99,7 @@ class WarmupCosineLRScheduler(LRScheduler):
         self.warmup_epochs = warmup_epochs
         self.max_epochs = max_epochs
         self.cosine_final = cosine_final
-        super().__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:


### PR DESCRIPTION
Hi team,

With the latest PyTorch updates since last week (https://pypi.org/project/torch/#history), I see that they completely dropped verbosity argument for their schedulers (and now seems to even break the code beyond deprecation warnings).

For reference: I tried training a Trackastra model today and it broke by training on `torch=2.7` as they removed the argument completely now.

With this fix, the training works for me. GTG from my side!