### PR TITLE
Update setup.cfg file to install `humanize` package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     matplotlib
     scipy
     pandas
-    numerize
+    humanize
     configargparse
     tensorboard
     pyyaml


### PR DESCRIPTION
Hi team,

Seems like `numerize` has been replaced by `humanize` for numerical formatting in a latest commit 16a454aa79f98b3737583ce0af8c7c1257812e08, but the package install is missing from `setup.cfg` (I hit this while trying to train a model)

I added `humanize` by simply replacing `numerize`!

GTG from my side!