### PR TITLE
Geff export

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Apart from that, no hyperparameters to choose :)
 ```python
 import torch
 from trackastra.model import Trackastra
-from trackastra.tracking import graph_to_ctc, graph_to_napari_tracks
+from trackastra.tracking import graph_to_ctc, graph_to_napari_tracks, write_to_geff
 from trackastra.data import example_data_bacteria
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -119,14 +119,20 @@ model = Trackastra.from_pretrained("general_2d", device=device)
 # model = Trackastra.from_folder('path/my_model_folder/', device=device)
 
 # Track the cells
-track_graph = model.track(imgs, masks, mode="greedy")  # or mode="ilp", or "greedy_nodiv"
+track_graph, masks_tracked = model.track(imgs, masks, mode="greedy")  # or mode="ilp", or "greedy_nodiv"
 
+# Relabel the masks and write to cell tracking challenge format (CTC), 
+ctc_tracks, ctc_masks = graph_to_ctc(
+    track_graph,
+    masks_tracked,
+    outdir="tracked_ctc",
+)
 
-# Write to cell tracking challenge format
-ctc_tracks, masks_tracked = graph_to_ctc(
-      track_graph,
-      masks,
-      outdir="tracked",
+# Or write to the graph exchange file format (GEFF)
+write_to_geff(
+    track_graph,
+    masks_tracked,
+    outdir="tracked_geff.zarr",
 )
 ```
 
@@ -139,7 +145,7 @@ napari_tracks, napari_tracks_graph, _ = graph_to_napari_tracks(track_graph)
 import napari
 v = napari.Viewer()
 v.add_image(imgs)
-v.add_labels(masks_tracked)
+v.add_labels(ctc_masks)
 v.add_tracks(data=napari_tracks, graph=napari_tracks_graph)
 ```
 </details>

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     edt
     joblib
     psutil
+    geff
 python_requires = >=3.10
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     joblib
     psutil
     geff
+    # zarr>=3  # Will need a python 3.11+ version
 python_requires = >=3.10
 include_package_data = True
 

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -30,7 +30,7 @@ def test_api(example_data):
 
     track_graph = model._track_from_predictions(predictions)
 
-    track_graph = model.track(
+    track_graph, masks_tracked = model.track(
         imgs,
         masks,
         mode="greedy",
@@ -44,9 +44,9 @@ def test_api(example_data):
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
-        _, _masks_tracked = graph_to_ctc(
+        _, _masks_ctc = graph_to_ctc(
             track_graph,
-            masks,
+            masks_tracked,
             outdir=tmp,
         )
 

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -60,7 +60,7 @@ def test_integration(name, device):
         device=device,
     )
     imgs, masks = example_data_hela()
-    track_graph = model.track(imgs, masks)
+    track_graph, _ = model.track(imgs, masks)
     assert (len(track_graph.edges), len(track_graph.nodes)) == length_edges_nodes[name]
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -41,7 +41,7 @@ def test_train_dry_run(download_gt_example_ctc):
         " --train_samples 2 --batch_size 2"
         " --num_decoder_layers 1 --num_decoder_layers 1"
         " --d_model 128 --num_workers 2"
-        # " --cachedir None"
+        " --cachedir None"
     )
     print(cmd)
     result = os.system(cmd)

--- a/trackastra/model/model_api.py
+++ b/trackastra/model/model_api.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Literal
 
 import dask.array as da
+import networkx as nx
 import numpy as np
 import tifffile
 import torch
@@ -11,7 +12,7 @@ import yaml
 from tqdm import tqdm
 
 from ..data import build_windows, get_features, load_tiff_timeseries
-from ..tracking import TrackGraph, build_graph, track_greedy
+from ..tracking import build_graph, track_greedy
 from ..utils import normalize
 from .model import TrackingTransformer
 from .predict import predict_windows
@@ -193,7 +194,7 @@ class Trackastra:
         max_neighbors: int = 10,
         delta_t: int = 1,
         **kwargs,
-    ):
+    ) -> nx.DiGraph:
         logger.info("Running greedy tracker")
         nodes = predictions["nodes"]
         weights = predictions["weights"]
@@ -226,7 +227,7 @@ class Trackastra:
         progbar_class=tqdm,
         n_workers: int = 0,
         **kwargs,
-    ) -> TrackGraph:
+    ) -> nx.DiGraph:
         """Track objects across time frames.
 
         This method links segmented objects across time frames using the specified
@@ -245,7 +246,7 @@ class Trackastra:
             **kwargs: Additional arguments passed to tracking algorithm.
 
         Returns:
-            TrackGraph containing the tracking results.
+            nx.DiGraph containing the tracking results.
         """
         predictions = self._predict(
             imgs,
@@ -265,7 +266,7 @@ class Trackastra:
         mode: Literal["greedy_nodiv", "greedy", "ilp"] = "greedy",
         normalize_imgs: bool = True,
         **kwargs,
-    ) -> tuple[TrackGraph, np.ndarray]:
+    ) -> tuple[nx.DiGraph, np.ndarray]:
         """Track objects directly from image and mask files on disk.
 
         This method supports both single tiff files and directories
@@ -285,7 +286,7 @@ class Trackastra:
             **kwargs: Additional arguments passed to tracking algorithm.
 
         Returns:
-            Tuple of (TrackGraph, tracked masks).
+            Tuple of (nx.DiGraph, tracked masks).
         """
         if not imgs_path.exists():
             raise FileNotFoundError(f"{imgs_path=} does not exist.")

--- a/trackastra/model/model_api.py
+++ b/trackastra/model/model_api.py
@@ -12,7 +12,7 @@ import yaml
 from tqdm import tqdm
 
 from ..data import build_windows, get_features, load_tiff_timeseries
-from ..tracking import build_graph, track_greedy
+from ..tracking import apply_solution_graph_to_masks, build_graph, track_greedy
 from ..utils import normalize
 from .model import TrackingTransformer
 from .predict import predict_windows
@@ -227,7 +227,7 @@ class Trackastra:
         progbar_class=tqdm,
         n_workers: int = 0,
         **kwargs,
-    ) -> nx.DiGraph:
+    ) -> tuple[nx.DiGraph, np.ndarray]:
         """Track objects across time frames.
 
         This method links segmented objects across time frames using the specified
@@ -257,7 +257,9 @@ class Trackastra:
         )
 
         track_graph = self._track_from_predictions(predictions, mode=mode, **kwargs)
-        return track_graph
+        masks_tracked = apply_solution_graph_to_masks(track_graph, masks)
+
+        return track_graph, masks_tracked
 
     def track_from_disk(
         self,
@@ -325,6 +327,4 @@ class Trackastra:
                 f"Img shape {imgs.shape} and mask shape {masks.shape} do not match."
             )
 
-        return self.track(
-            imgs, masks, mode, normalize_imgs=normalize_imgs, **kwargs
-        ), masks
+        return self.track(imgs, masks, mode, normalize_imgs=normalize_imgs, **kwargs)

--- a/trackastra/tracking/__init__.py
+++ b/trackastra/tracking/__init__.py
@@ -6,6 +6,7 @@ from .tracking import (
     track_greedy,
 )
 from .utils import (
+    apply_solution_graph_to_masks,
     ctc_to_graph,
     ctc_to_napari_tracks,
     graph_to_ctc,

--- a/trackastra/tracking/__init__.py
+++ b/trackastra/tracking/__init__.py
@@ -13,4 +13,5 @@ from .utils import (
     graph_to_edge_table,
     graph_to_napari_tracks,
     linear_chains,
+    write_to_geff,
 )

--- a/trackastra/tracking/ilp.py
+++ b/trackastra/tracking/ilp.py
@@ -62,7 +62,7 @@ def track_ilp(
     ilp_config: str = "gt",
     params_file: str | None = None,
     **kwargs,
-):
+) -> nx.DiGraph:
     candidate_graph_motile = motile.TrackGraph(candidate_graph, frame_attribute="time")
 
     ilp, _used_costs = solve_full_ilp(
@@ -140,7 +140,7 @@ def solve_full_ilp(
     return solver, vars(used_costs)
 
 
-def solution_to_graph(solver, base_graph):
+def solution_to_graph(solver, base_graph) -> nx.DiGraph:
     new_graph = nx.DiGraph()
     node_indicators = solver.get_variables(motile.variables.NodeSelected)
     edge_indicators = solver.get_variables(motile.variables.EdgeSelected)

--- a/trackastra/tracking/tracking.py
+++ b/trackastra/tracking/tracking.py
@@ -89,7 +89,7 @@ def build_graph(
     max_distance: int | None = None,
     max_neighbors: int | None = None,
     delta_t=1,
-):
+) -> nx.DiGraph:
     logger.info(f"Build candidate graph with {delta_t=}")
     G = nx.DiGraph()
 


### PR DESCRIPTION
- Adds a writer to the graph exchange file format
- Introduces breaking API change for `Trackastra.track`. It now takes care of producing matching masks to the solution graph, which was done before only when converting to CTC format.