### PR TITLE
Update README with currently required GEFF installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Trackastra can then be installed from PyPI using `pip`:
 pip install trackastra
 ```
 
+Currently, Trackastra needs GEFF in version 0.5.0. Geff can be installed from PyPI using `pip`:
+```bash
+pip install geff==0.5.0
+```
+
 ### With ILP support
 For tracking with an integer linear program (ILP, which is optional)
 ```bash


### PR DESCRIPTION
This PR suggests to add installation instructions for GEFF version 0.5.0.

Since version 0.4.0 trackastra seems to have a dependency on geff, which is not mentioned in the readme.md

E.g.

`from trackastra.model import Trackastra`

leads to:

```
File [~\AppData\Local\mambaforge\envs\trackastra\lib\site-packages\trackastra\tracking\utils.py:10](http://localhost:57155/lab/tree/~/AppData/Local/mambaforge/envs/trackastra/lib/site-packages/trackastra/tracking/utils.py#line=9)
      8 import tifffile
      9 import zarr
---> 10 from geff import write_nx
     11 from skimage.measure import regionprops
     12 from tqdm import tqdm

ImportError: cannot import name 'write_nx' from 'geff' ([envs\trackastra\lib\site-packages\geff\__init__.py](file:////envs/trackastra/lib/site-packages/geff/__init__.py))
```

which currently can only be avoid, if

`pip install geff==0.5.0` 

is run in the trackastra python environment.


Adding the *0.5.0* is actually important, since there is a new geff (1.0.0.1.0) available on PyPi, which apparently does not have the required `write_nx()` method anymore.