### PR TITLE
Add support for training trackastra with SAM2 features

### DIFF
--- a/scripts/example_pretrained_feats_config.yaml
+++ b/scripts/example_pretrained_feats_config.yaml
@@ -1,0 +1,51 @@
+name: example_sam2_finetune
+outdir: runs
+
+# Data
+ndim: 2
+input_train:
+  - data/ctc/Fluo-N2DL-HeLa/02
+input_val:
+  - data/ctc/Fluo-N2DL-HeLa/01
+detection_folders:
+  - TRA
+
+# SAM2 feature backbone
+# Requires trackastra_pretrained_feats to be installed.
+# Use features: wrfeat to fall back to the standard feature extractor.
+features: pretrained_feats_aug
+pretrained_feats_model: facebook/sam2.1-hiera-base-plus  # HuggingFace model name
+pretrained_feats_mode: mean_patches_exact  # recommended pooling mode
+pretrained_feats_additional_props: regionprops_small  # concatenated with SAM2 features
+reduced_pretrained_feat_dim: 128  # FC layer output dim fed to encoder
+pretrained_n_augs: 3  # augmented copies per sequence; increase for larger datasets
+rotate_features: true  # feature disambiguation; recommended with pretrained_feats_aug
+
+# Finetuning from a pretrained SAM2-features model.
+# Remove or set to null to train from scratch (not supported for pretrained_feats).
+model: general_2d_w_SAM2_features  # auto-downloaded if not already present
+
+# Model architecture - must match the pretrained model config
+d_model: 256
+num_encoder_layers: 4
+num_decoder_layers: 4
+dropout: 0.05
+window: 4
+attn_dist_mode: v1
+causal_norm: none
+
+# Training
+epochs: 500
+warmup_epochs: 5
+train_samples: 32000
+batch_size: 16
+max_tokens: 2048
+lr: 1e-4
+weight_decay: 0.01
+weight_by_dataset: true
+crop_size:
+  - 320
+  - 320
+
+# Caching
+cachedir: .cache

--- a/scripts/example_pretrained_feats_config.yaml
+++ b/scripts/example_pretrained_feats_config.yaml
@@ -20,6 +20,7 @@ pretrained_feats_additional_props: regionprops_small  # concatenated with SAM2 f
 reduced_pretrained_feat_dim: 128  # FC layer output dim fed to encoder
 pretrained_n_augs: 3  # augmented copies per sequence; increase for larger datasets
 rotate_features: true  # feature disambiguation; recommended with pretrained_feats_aug
+rotate_feature_axes: y  # y|x|both; keep y to finetune the released SAM2 model
 
 # Finetuning from a pretrained SAM2-features model. Use pretrained_model_path instead to
 # start from a local model folder, or remove both to train from scratch, in which case the

--- a/scripts/example_pretrained_feats_config.yaml
+++ b/scripts/example_pretrained_feats_config.yaml
@@ -21,11 +21,14 @@ reduced_pretrained_feat_dim: 128  # FC layer output dim fed to encoder
 pretrained_n_augs: 3  # augmented copies per sequence; increase for larger datasets
 rotate_features: true  # feature disambiguation; recommended with pretrained_feats_aug
 
-# Finetuning from a pretrained SAM2-features model.
-# Remove or set to null to train from scratch (not supported for pretrained_feats).
+# Finetuning from a pretrained SAM2-features model. Use pretrained_model_path instead to
+# start from a local model folder, or remove both to train from scratch, in which case the
+# architecture below is used as is instead of being checked against the loaded config.
 model: general_2d_w_SAM2_features  # auto-downloaded if not already present
 
-# Model architecture - must match the pretrained model config
+# Model architecture - must match the pretrained model config, otherwise loading it
+# raises a mismatch error. pos_embed_per_dim, feat_embed_per_dim, attn_positional_bias
+# and spatial_pos_cutoff are left at their defaults, which already match.
 d_model: 256
 num_encoder_layers: 4
 num_decoder_layers: 4
@@ -35,7 +38,7 @@ attn_dist_mode: v1
 causal_norm: none
 
 # Training
-epochs: 500
+epochs: 1000
 warmup_epochs: 5
 train_samples: 32000
 batch_size: 16
@@ -43,9 +46,12 @@ max_tokens: 2048
 lr: 1e-4
 weight_decay: 0.01
 weight_by_dataset: true
+augment: 3
+delta_cutoff: 1
 crop_size:
   - 320
   - 320
 
 # Caching
 cachedir: .cache
+compress: true

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1112,7 +1112,7 @@ def parse_train_args():
         "--pretrained_n_augs",
         type=int,
         default=15,
-        help="Number of augmentations for pretrained_feats_aug feature extraction",
+        help="Number of augmented dataset copies to create for pretrained features extraction",
     )
     parser.add_argument(
         "--reduced_pretrained_feat_dim",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -208,7 +208,13 @@ class WrappedLightningModule(pl.LightningModule):
         padding_mask = batch["padding_mask"]
         padding_mask = padding_mask.bool()
 
-        A_pred = self.model(coords, feats, padding_mask=padding_mask)
+        pretrained_feats = batch.get("pretrained_feats", None)
+        if pretrained_feats is not None and pretrained_feats.numel() > 0:
+            pretrained_feats = pretrained_feats.to(coords.device)
+        else:
+            pretrained_feats = None
+
+        A_pred = self.model(coords, feats, pretrained_features=pretrained_feats, padding_mask=padding_mask)
         # remove inf values that might happen due to float16 numerics
         A_pred.clamp_(torch.finfo(torch.float16).min, torch.finfo(torch.float16).max)
 
@@ -632,7 +638,8 @@ class MyModelCheckpoint(pl.pytorch.callbacks.Callback):
 
 def create_run_name(args):
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    # name = f"{timestamp}_{args.name}_feats_{args.features}_pos_{args.attn_positional_bias}_causal_norm_{args.causal_norm}"
+    # name = f"{timestamp}_{args.name}_feats_{args.features}_pos_" + \
+    #     f"{args.attn_positional_bias}_causal_norm_{args.causal_norm}"
     if args.timestamp:
         name = f"{timestamp}_{args.name}"
     else:
@@ -817,6 +824,9 @@ def train(args):
         sanity_dist=args.sanity_dist,
         crop_size=args.crop_size,
         compress=args.compress,
+        pretrained_feats_model=args.pretrained_feats_model,
+        pretrained_feats_mode=args.pretrained_feats_mode,
+        pretrained_feats_additional_props=args.pretrained_feats_additional_props,
     )
     sampler_kwargs = dict(
         batch_size=args.batch_size,
@@ -920,7 +930,7 @@ def train(args):
     # Compiling does not work!
     # model_lightning = torch.compile(model_lightning)
 
-    # if logdir already exists and --resume option is set, load the last checkpoint (eg when continuing training after crash)
+    # if logdir already exists and --resume option is set, load the last checkpoint (eg when continuing training after crash)  # noqa
     if logdir is not None and logdir.exists() and args.resume:
         logging.info("logdir exists, loading last state of model")
         fpath = model_lightning.checkpoint_path(logdir)
@@ -1065,8 +1075,68 @@ def parse_train_args():
             "patch",
             "patch_regionprops",
             "wrfeat",
+            "pretrained_feats",
+            "pretrained_feats_aug",
         ],
         default="wrfeat",
+    )
+    parser.add_argument(
+        "--pretrained_feats_model",
+        type=str,
+        default=None,
+        help="SAM2 model name for pretrained feature extraction (e.g. facebook/sam2.1-hiera-base-plus)",
+    )
+    parser.add_argument(
+        "--pretrained_feats_mode",
+        type=str,
+        default="mean_patches_exact",
+        help="Pooling mode for pretrained features",
+    )
+    parser.add_argument(
+        "--pretrained_feats_additional_props",
+        type=none_or_str,
+        default=None,
+        help="Additional region properties to concatenate with pretrained features (e.g. regionprops_small)",
+    )
+    parser.add_argument(
+        "--pretrained_n_augs",
+        type=int,
+        default=15,
+        help="Number of augmentations for pretrained_feats_aug feature extraction",
+    )
+    parser.add_argument(
+        "--reduced_pretrained_feat_dim",
+        type=int,
+        default=None,
+        help="Reduce pretrained feature dimension via PCA to this size",
+    )
+    parser.add_argument(
+        "--rotate_features",
+        type=str2bool,
+        default=False,
+        help="Apply random rotation augmentation to pretrained features during training",
+    )
+    parser.add_argument(
+        "--disable_all_coords",
+        type=str2bool,
+        default=False,
+    )
+    parser.add_argument(
+        "--disable_xy_coords",
+        type=str2bool,
+        default=False,
+    )
+    parser.add_argument(
+        "--pretrained_model_path",
+        type=none_or_str,
+        default=None,
+        help="Path to a local pretrained model folder (overrides --model for loading weights)",
+    )
+    parser.add_argument(
+        "--weight_decay",
+        type=float,
+        default=0.0,
+        help="AdamW weight decay",
     )
     parser.add_argument(
         "--causal_norm",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -215,7 +215,12 @@ class WrappedLightningModule(pl.LightningModule):
             pretrained_feats = None
 
         if pretrained_feats is not None:
-            A_pred = self.model(coords, feats, pretrained_features=pretrained_feats, padding_mask=padding_mask)
+            A_pred = self.model(
+                coords,
+                feats,
+                pretrained_features=pretrained_feats,
+                padding_mask=padding_mask,
+            )
         else:
             A_pred = self.model(coords, feats, padding_mask=padding_mask)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1123,8 +1123,8 @@ def parse_train_args():
     parser.add_argument(
         "--rotate_features",
         type=str2bool,
-        default=False,
-        help="Apply random rotation augmentation to pretrained features during training",
+        default=True,
+        help="Apply feature disambiguation to pretrained features based on coordinates to mitigate overfitting and avoid proximity-induced ambiguity in pretrained features",
     )
     parser.add_argument(
         "--disable_all_coords",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -214,7 +214,11 @@ class WrappedLightningModule(pl.LightningModule):
         else:
             pretrained_feats = None
 
-        A_pred = self.model(coords, feats, pretrained_features=pretrained_feats, padding_mask=padding_mask)
+        if pretrained_feats is not None:
+            A_pred = self.model(coords, feats, pretrained_features=pretrained_feats, padding_mask=padding_mask)
+        else:
+            A_pred = self.model(coords, feats, padding_mask=padding_mask)
+
         # remove inf values that might happen due to float16 numerics
         A_pred.clamp_(torch.finfo(torch.float16).min, torch.finfo(torch.float16).max)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1094,7 +1094,7 @@ def parse_train_args():
         "--pretrained_feats_model",
         type=str,
         default=None,
-        help="SAM2 model name for pretrained feature extraction (e.g. facebook/sam2.1-hiera-base-plus)",
+        help="Model name for pretrained feature extraction (e.g. facebook/sam2.1-hiera-base-plus)",
     )
     parser.add_argument(
         "--pretrained_feats_mode",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -934,7 +934,8 @@ def train(args):
     # Compiling does not work!
     # model_lightning = torch.compile(model_lightning)
 
-    # if logdir already exists and --resume option is set, load the last checkpoint (eg when continuing training after crash)  # noqa
+    # if logdir already exists and --resume option is set,
+    # load the last checkpoint (eg when continuing training after crash)
     if logdir is not None and logdir.exists() and args.resume:
         logging.info("logdir exists, loading last state of model")
         fpath = model_lightning.checkpoint_path(logdir)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -239,10 +239,14 @@ class WrappedLightningModule(pl.LightningModule):
 
         if self.causal_norm != "none":
             # TODO speedup: I could softmax only the part of the matrix (upper triangular) that is not masked out
-            A_pred_soft = torch.stack([
-                blockwise_causal_norm(_A, _t, mode=self.causal_norm, mask_invalid=_m)
-                for _A, _t, _m in zip(A_pred, timepoints, mask_invalid)
-            ])
+            A_pred_soft = torch.stack(
+                [
+                    blockwise_causal_norm(
+                        _A, _t, mode=self.causal_norm, mask_invalid=_m
+                    )
+                    for _A, _t, _m in zip(A_pred, timepoints, mask_invalid)
+                ]
+            )
             with torch.cuda.amp.autocast(enabled=False):
                 if len(A) > 0:
                     # debug
@@ -326,7 +330,9 @@ class WrappedLightningModule(pl.LightningModule):
             return None
 
     def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(self.parameters(), lr=self.lr, weight_decay=self.weight_decay)
+        optimizer = torch.optim.AdamW(
+            self.parameters(), lr=self.lr, weight_decay=self.weight_decay
+        )
         return dict(
             optimizer=optimizer,
             lr_scheduler=WarmupCosineLRScheduler(
@@ -711,7 +717,10 @@ def train(args):
             " Provide --model or --pretrained_model_path with a compatible pretrained model."
         )
 
-    if args.features in ("pretrained_feats", "pretrained_feats_aug") and args.pretrained_feats_model is None:
+    if (
+        args.features in ("pretrained_feats", "pretrained_feats_aug")
+        and args.pretrained_feats_model is None
+    ):
         raise ValueError(
             "pretrained_feats modes require --pretrained_feats_model"
             " (e.g. facebook/sam2.1-hiera-base-plus)"
@@ -918,7 +927,11 @@ def train(args):
         callbacks.append(ExampleImages())
 
     # load the model if it was given
-    model_path = args.pretrained_model_path if args.pretrained_model_path is not None else args.model
+    model_path = (
+        args.pretrained_model_path
+        if args.pretrained_model_path is not None
+        else args.model
+    )
     if model_path is not None and model_path in _MODELS:
         logger.info(f"Downloading pretrained model '{model_path}'")
         model_path = str(download_pretrained(model_path))

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -37,6 +37,7 @@ from trackastra.data import (
 )
 from trackastra.data.distributed import BalancedDataModule
 from trackastra.model import TrackingTransformer
+from trackastra.model.pretrained import _MODELS, download_pretrained
 from trackastra.utils import (
     blockwise_causal_norm,
     blockwise_sum,
@@ -176,6 +177,7 @@ class WrappedLightningModule(pl.LightningModule):
         warmup_epochs: int = 10,
         max_epochs: int = 100,
         learning_rate: float = 1e-5,
+        weight_decay: float = 1e-5,
         causal_norm: str = "none",
         delta_cutoff: int = 2,
         tracking_frequency: int = -1,  # log TRA metrics every that epochs
@@ -195,6 +197,7 @@ class WrappedLightningModule(pl.LightningModule):
         self.batch_val_tb = None
 
         self.lr = learning_rate
+        self.weight_decay = weight_decay
         self.tracking_frequency = tracking_frequency
         self.warmup_epochs = warmup_epochs
         self.max_epochs = max_epochs
@@ -323,7 +326,7 @@ class WrappedLightningModule(pl.LightningModule):
             return None
 
     def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(self.parameters(), lr=self.lr, weight_decay=1e-5)
+        optimizer = torch.optim.AdamW(self.parameters(), lr=self.lr, weight_decay=self.weight_decay)
         return dict(
             optimizer=optimizer,
             lr_scheduler=WarmupCosineLRScheduler(
@@ -698,6 +701,22 @@ def train(args):
         "cuda" if args.device == "cuda" and torch.cuda.is_available() else "cpu"
     )
     args.seed = seed(args.seed)
+    if (
+        args.features in ("pretrained_feats", "pretrained_feats_aug")
+        and args.model is None
+        and args.pretrained_model_path is None
+    ):
+        raise ValueError(
+            "Training a pretrained_feats model from scratch is not supported."
+            " Provide --model or --pretrained_model_path with a compatible pretrained model."
+        )
+
+    if args.features in ("pretrained_feats", "pretrained_feats_aug") and args.pretrained_feats_model is None:
+        raise ValueError(
+            "pretrained_feats modes require --pretrained_feats_model"
+            " (e.g. facebook/sam2.1-hiera-base-plus)"
+        )
+
     if args.model is None:
         logger.warning("Training from scratch, this is slow!\n")
 
@@ -770,6 +789,11 @@ def train(args):
             sanity_dist=args.sanity_dist,
             crop_size=args.crop_size,
             compress=args.compress,
+            pretrained_feats_model=args.pretrained_feats_model,
+            pretrained_feats_mode=args.pretrained_feats_mode,
+            pretrained_feats_additional_props=args.pretrained_feats_additional_props,
+            pretrained_n_augs=args.pretrained_n_augs,
+            rotate_features=args.rotate_features,
         )
         dummy_model = TrackingTransformer(
             coord_dim=dummy_data.ndim,
@@ -793,6 +817,7 @@ def train(args):
             warmup_epochs=args.warmup_epochs,
             max_epochs=args.epochs,
             learning_rate=args.lr,
+            weight_decay=args.weight_decay,
             delta_cutoff=args.delta_cutoff,
             causal_norm=args.causal_norm,
             tracking_frequency=args.tracking_frequency,
@@ -836,6 +861,8 @@ def train(args):
         pretrained_feats_model=args.pretrained_feats_model,
         pretrained_feats_mode=args.pretrained_feats_mode,
         pretrained_feats_additional_props=args.pretrained_feats_additional_props,
+        pretrained_n_augs=args.pretrained_n_augs,
+        rotate_features=args.rotate_features,
     )
     sampler_kwargs = dict(
         batch_size=args.batch_size,
@@ -891,8 +918,12 @@ def train(args):
         callbacks.append(ExampleImages())
 
     # load the model if it was given
-    if args.model is not None:
-        fpath = Path(args.model)
+    model_path = args.pretrained_model_path if args.pretrained_model_path is not None else args.model
+    if model_path is not None and model_path in _MODELS:
+        logger.info(f"Downloading pretrained model '{model_path}'")
+        model_path = str(download_pretrained(model_path))
+    if model_path is not None:
+        fpath = Path(model_path)
 
         # allow for checkpoints to be loaded too
         if fpath.is_file():
@@ -930,6 +961,7 @@ def train(args):
         warmup_epochs=args.warmup_epochs,
         max_epochs=args.epochs,
         learning_rate=args.lr,
+        weight_decay=args.weight_decay,
         delta_cutoff=args.delta_cutoff,
         causal_norm=args.causal_norm,
         tracking_frequency=args.tracking_frequency,
@@ -951,6 +983,7 @@ def train(args):
                 warmup_epochs=args.warmup_epochs,
                 max_epochs=args.epochs,
                 learning_rate=args.lr,
+                weight_decay=args.weight_decay,
                 delta_cutoff=args.delta_cutoff,
                 causal_norm=args.causal_norm,
                 tracking_frequency=args.tracking_frequency,
@@ -1094,13 +1127,13 @@ def parse_train_args():
         "--pretrained_feats_model",
         type=str,
         default=None,
-        help="SAM2 model name for pretrained feature extraction (e.g. facebook/sam2.1-hiera-base-plus)",
+        help="Model name for pretrained feature extraction (e.g. facebook/sam2.1-hiera-base-plus)",
     )
     parser.add_argument(
         "--pretrained_feats_mode",
         type=str,
         default="mean_patches_exact",
-        help="Pooling mode for pretrained features",
+        help="Pooling mode for aggregating patch embeddings per detection (recommended: mean_patches_exact)",
     )
     parser.add_argument(
         "--pretrained_feats_additional_props",
@@ -1111,30 +1144,32 @@ def parse_train_args():
     parser.add_argument(
         "--pretrained_n_augs",
         type=int,
-        default=15,
-        help="Number of augmentations for pretrained_feats_aug feature extraction",
+        default=3,
+        help="Number of augmented dataset copies for pretrained_feats_aug; increase for larger datasets (e.g. 25)",
     )
     parser.add_argument(
         "--reduced_pretrained_feat_dim",
         type=int,
         default=None,
-        help="Reduce pretrained feature dimension via PCA to this size",
+        help="Dimension of pretrained features after the FC layer fed to the encoder (concatenated with additional region props if set); recommended: 128",
     )
     parser.add_argument(
         "--rotate_features",
         type=str2bool,
-        default=False,
-        help="Apply random rotation augmentation to pretrained features during training",
+        default=True,
+        help="Apply feature disambiguation to pretrained features based on coordinates to mitigate overfitting and avoid proximity-induced ambiguity in pretrained features",
     )
     parser.add_argument(
         "--disable_all_coords",
         type=str2bool,
         default=False,
+        help="Disable all coordinate inputs to the model (use features only)",
     )
     parser.add_argument(
         "--disable_xy_coords",
         type=str2bool,
         default=False,
+        help="Disable XY coordinate inputs to the model (keep only Z/T coords)",
     )
     parser.add_argument(
         "--pretrained_model_path",
@@ -1145,7 +1180,7 @@ def parse_train_args():
     parser.add_argument(
         "--weight_decay",
         type=float,
-        default=0.0,
+        default=1e-5,
         help="AdamW weight decay",
     )
     parser.add_argument(

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -239,14 +239,10 @@ class WrappedLightningModule(pl.LightningModule):
 
         if self.causal_norm != "none":
             # TODO speedup: I could softmax only the part of the matrix (upper triangular) that is not masked out
-            A_pred_soft = torch.stack(
-                [
-                    blockwise_causal_norm(
-                        _A, _t, mode=self.causal_norm, mask_invalid=_m
-                    )
-                    for _A, _t, _m in zip(A_pred, timepoints, mask_invalid)
-                ]
-            )
+            A_pred_soft = torch.stack([
+                blockwise_causal_norm(_A, _t, mode=self.causal_norm, mask_invalid=_m)
+                for _A, _t, _m in zip(A_pred, timepoints, mask_invalid)
+            ])
             with torch.cuda.amp.autocast(enabled=False):
                 if len(A) > 0:
                     # debug

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -215,7 +215,9 @@ class WrappedLightningModule(pl.LightningModule):
             pretrained_feats = pretrained_feats.to(coords.device)
             if torch.any(torch.isnan(pretrained_feats)):
                 nan_dims = torch.any(torch.isnan(pretrained_feats), dim=-1)
-                raise ValueError(f"NaN in pretrained features in dimensions: {nan_dims}")
+                raise ValueError(
+                    f"NaN in pretrained features in dimensions: {nan_dims}"
+                )
         else:
             pretrained_feats = None
 
@@ -849,7 +851,9 @@ def train(args):
             # Dispatches create() to TrackingTransformerwPretrainedFeats, so that the
             # preallocated batch goes through the same projection as during training.
             dummy_config["pretrained_feat_dim"] = dummy_data.pretrained_feat_dim
-            dummy_config["reduced_pretrained_feat_dim"] = args.reduced_pretrained_feat_dim
+            dummy_config["reduced_pretrained_feat_dim"] = (
+                args.reduced_pretrained_feat_dim
+            )
             dummy_config["disable_xy_coords"] = args.disable_xy_coords
             dummy_config["disable_all_coords"] = args.disable_all_coords
         dummy_model = TrackingTransformer.create(dummy_config)
@@ -1007,7 +1011,9 @@ def train(args):
         )
         if args.features in ("pretrained_feats", "pretrained_feats_aug"):
             model_config["pretrained_feat_dim"] = pretrained_backbone_feat_dim(args)
-            model_config["reduced_pretrained_feat_dim"] = args.reduced_pretrained_feat_dim
+            model_config["reduced_pretrained_feat_dim"] = (
+                args.reduced_pretrained_feat_dim
+            )
             model_config["disable_xy_coords"] = args.disable_xy_coords
             model_config["disable_all_coords"] = args.disable_all_coords
         model = TrackingTransformer.create(model_config)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -213,6 +213,9 @@ class WrappedLightningModule(pl.LightningModule):
         pretrained_feats = batch.get("pretrained_feats", None)
         if pretrained_feats is not None and pretrained_feats.numel() > 0:
             pretrained_feats = pretrained_feats.to(coords.device)
+            if torch.any(torch.isnan(pretrained_feats)):
+                nan_dims = torch.any(torch.isnan(pretrained_feats), dim=-1)
+                raise ValueError(f"NaN in pretrained features in dimensions: {nan_dims}")
         else:
             pretrained_feats = None
 
@@ -649,6 +652,24 @@ class MyModelCheckpoint(pl.pytorch.callbacks.Callback):
 #     return weight
 
 
+def pretrained_backbone_feat_dim(args):
+    """Embedding dim of the pretrained backbone, e.g. 256 for SAM2."""
+    from trackastra_pretrained_feats.pretrained_features import (
+        AVAILABLE_PRETRAINED_BACKBONES,
+    )
+
+    return AVAILABLE_PRETRAINED_BACKBONES[args.pretrained_feats_model]["feat_dim"]
+
+
+def pretrained_additional_feat_dim(args):
+    """Stacked dim of the region props concatenated with the pretrained features."""
+    if args.pretrained_feats_additional_props is None:
+        return 0
+    from trackastra.data.wrfeat import WRFeatures
+
+    return WRFeatures.PROPERTIES_DIMS[args.pretrained_feats_additional_props][args.ndim]
+
+
 def create_run_name(args):
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     # name = f"{timestamp}_{args.name}_feats_{args.features}_pos_" + \
@@ -702,24 +723,33 @@ def train(args):
         "cuda" if args.device == "cuda" and torch.cuda.is_available() else "cpu"
     )
     args.seed = seed(args.seed)
-    if (
-        args.features in ("pretrained_feats", "pretrained_feats_aug")
-        and args.model is None
-        and args.pretrained_model_path is None
-    ):
-        raise ValueError(
-            "Training a pretrained_feats model from scratch is not supported."
-            " Provide --model or --pretrained_model_path with a compatible pretrained model."
+    if args.features in ("pretrained_feats", "pretrained_feats_aug"):
+        if args.pretrained_feats_model is None:
+            raise ValueError(
+                "pretrained_feats modes require --pretrained_feats_model"
+                " (e.g. facebook/sam2.1-hiera-base-plus)"
+            )
+        if args.pretrained_feats_mode is None:
+            raise ValueError("pretrained_feats modes require --pretrained_feats_mode")
+
+        from trackastra_pretrained_feats.pretrained_features import (
+            AVAILABLE_PRETRAINED_BACKBONES,
         )
 
-    if (
-        args.features in ("pretrained_feats", "pretrained_feats_aug")
-        and args.pretrained_feats_model is None
-    ):
-        raise ValueError(
-            "pretrained_feats modes require --pretrained_feats_model"
-            " (e.g. facebook/sam2.1-hiera-base-plus)"
-        )
+        if args.pretrained_feats_model not in AVAILABLE_PRETRAINED_BACKBONES:
+            raise ValueError(
+                f"Unknown pretrained model '{args.pretrained_feats_model}'. Available:"
+                f" {tuple(AVAILABLE_PRETRAINED_BACKBONES.keys())}"
+            )
+        if args.pretrained_feats_additional_props is None:
+            # Without region props the pretrained features are the only features, and
+            # TrackingTransformerwPretrainedFeats.forward then squeezes away the batch
+            # dimension for single-element batches, which breaks the concat with the
+            # positional encoding. Guard until that is fixed in trackastra_pretrained_feats.
+            raise ValueError(
+                "pretrained_feats modes currently require --pretrained_feats_additional_props"
+                " (e.g. regionprops_small)"
+            )
 
     if args.model is None:
         logger.warning("Training from scratch, this is slow!\n")
@@ -799,7 +829,7 @@ def train(args):
             pretrained_n_augs=args.pretrained_n_augs,
             rotate_features=args.rotate_features,
         )
-        dummy_model = TrackingTransformer(
+        dummy_config = dict(
             coord_dim=dummy_data.ndim,
             feat_dim=dummy_data.feat_dim,
             d_model=args.d_model,
@@ -815,6 +845,14 @@ def train(args):
             attn_dist_mode=args.attn_dist_mode,
             causal_norm=args.causal_norm,
         )
+        if args.features in ("pretrained_feats", "pretrained_feats_aug"):
+            # Dispatches create() to TrackingTransformerwPretrainedFeats, so that the
+            # preallocated batch goes through the same projection as during training.
+            dummy_config["pretrained_feat_dim"] = dummy_data.pretrained_feat_dim
+            dummy_config["reduced_pretrained_feat_dim"] = args.reduced_pretrained_feat_dim
+            dummy_config["disable_xy_coords"] = args.disable_xy_coords
+            dummy_config["disable_all_coords"] = args.disable_all_coords
+        dummy_model = TrackingTransformer.create(dummy_config)
 
         dummy_model_lightning = WrappedLightningModule(
             model=dummy_model,
@@ -944,7 +982,11 @@ def train(args):
             model = TrackingTransformer.from_folder(fpath, args=args)
     else:
         feat_dim = 0 if args.features == "none" else 7 if args.ndim == 2 else 12
-        model = TrackingTransformer(
+        if args.features in ("pretrained_feats", "pretrained_feats_aug"):
+            # The datasets are only built inside trainer.fit(), so the feature dims have to
+            # come from the config rather than from a loaded CTCData.
+            feat_dim = pretrained_additional_feat_dim(args)
+        model_config = dict(
             # coord_dim=datasets["train"].datasets[0].ndim,
             coord_dim=args.ndim,
             # feat_dim=datasets["train"].datasets[0].feat_dim,
@@ -963,6 +1005,12 @@ def train(args):
             attn_dist_mode=args.attn_dist_mode,
             causal_norm=args.causal_norm,
         )
+        if args.features in ("pretrained_feats", "pretrained_feats_aug"):
+            model_config["pretrained_feat_dim"] = pretrained_backbone_feat_dim(args)
+            model_config["reduced_pretrained_feat_dim"] = args.reduced_pretrained_feat_dim
+            model_config["disable_xy_coords"] = args.disable_xy_coords
+            model_config["disable_all_coords"] = args.disable_all_coords
+        model = TrackingTransformer.create(model_config)
 
     model_lightning = WrappedLightningModule(
         model=model,
@@ -1158,14 +1206,16 @@ def parse_train_args():
     parser.add_argument(
         "--reduced_pretrained_feat_dim",
         type=int,
-        default=None,
-        help="Dimension of pretrained features after the FC layer fed to the encoder (concatenated with additional region props if set); recommended: 128",
+        default=128,
+        help="Dimension of pretrained features after the FC layer fed to the encoder"
+        " (concatenated with additional region props if set)",
     )
     parser.add_argument(
         "--rotate_features",
         type=str2bool,
         default=True,
-        help="Apply feature disambiguation to pretrained features based on coordinates to mitigate overfitting and avoid proximity-induced ambiguity in pretrained features",
+        help="Apply feature disambiguation to pretrained features based on coordinates to"
+        " mitigate overfitting and avoid proximity-induced ambiguity in pretrained features",
     )
     parser.add_argument(
         "--disable_all_coords",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -830,6 +830,7 @@ def train(args):
             pretrained_feats_additional_props=args.pretrained_feats_additional_props,
             pretrained_n_augs=args.pretrained_n_augs,
             rotate_features=args.rotate_features,
+            rotate_feature_axes=args.rotate_feature_axes,
         )
         dummy_config = dict(
             coord_dim=dummy_data.ndim,
@@ -909,6 +910,7 @@ def train(args):
         pretrained_feats_additional_props=args.pretrained_feats_additional_props,
         pretrained_n_augs=args.pretrained_n_augs,
         rotate_features=args.rotate_features,
+        rotate_feature_axes=args.rotate_feature_axes,
     )
     sampler_kwargs = dict(
         batch_size=args.batch_size,
@@ -1222,6 +1224,15 @@ def parse_train_args():
         default=True,
         help="Apply feature disambiguation to pretrained features based on coordinates to"
         " mitigate overfitting and avoid proximity-induced ambiguity in pretrained features",
+    )
+    parser.add_argument(
+        "--rotate_feature_axes",
+        type=str,
+        choices=["y", "x", "both"],
+        default="y",
+        help="Spatial coordinates driving the feature rotation angle. 'y'/'x' use that"
+        " coordinate alone, 'both' alternates between them across feature pairs. Keep 'y'"
+        " to finetune general_2d_w_SAM2_features, which was trained that way",
     )
     parser.add_argument(
         "--disable_all_coords",

--- a/trackastra/data/__init__.py
+++ b/trackastra/data/__init__.py
@@ -1,5 +1,3 @@
-# ruff: noqa: F401
-
 # Core data utilities (no training dependencies required)
 from .data import (
     CTCData,

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -181,12 +181,18 @@ class CTCData(Dataset):
         self.ndim = ndim
         self.features = features
         self.pretrained_feats_model = kwargs.get("pretrained_feats_model", None)
-        self.pretrained_feats_mode = kwargs.get("pretrained_feats_mode", "mean_patches_exact")
-        self.pretrained_feats_additional_props = kwargs.get("pretrained_feats_additional_props", None)
+        self.pretrained_feats_mode = kwargs.get(
+            "pretrained_feats_mode", "mean_patches_exact"
+        )
+        self.pretrained_feats_additional_props = kwargs.get(
+            "pretrained_feats_additional_props", None
+        )
 
-        if features not in (
-            "none", "wrfeat", "pretrained_feats", "pretrained_feats_aug"
-        ) and features not in _PROPERTIES[ndim]:
+        if (
+            features
+            not in ("none", "wrfeat", "pretrained_feats", "pretrained_feats_aug")
+            and features not in _PROPERTIES[ndim]
+        ):
             raise ValueError(
                 f"'{features}' not one of the supported {ndim}D features"
                 f" {tuple(_PROPERTIES[ndim].keys())}"
@@ -522,7 +528,7 @@ class CTCData(Dataset):
             tifffile.imread(f).astype(dtype)
             for f in tqdm(
                 sorted(folder.glob("*.tif"))[
-                    self.start_frame: self.end_frame: self.downscale_temporal
+                    self.start_frame : self.end_frame : self.downscale_temporal
                 ],
                 leave=False,
                 desc=f"Loading [{self.start_frame}:{self.end_frame}]",
@@ -1117,7 +1123,11 @@ class CTCData(Dataset):
 
             # build features
             if self.features in ("pretrained_feats", "pretrained_feats_aug"):
-                from trackastra_pretrained_feats import FeatureExtractor, WRPretrainedFeatures
+                from trackastra_pretrained_feats import (
+                    FeatureExtractor,
+                    WRPretrainedFeatures,
+                )
+
                 device = "cuda" if torch.cuda.is_available() else "cpu"
                 feature_extractor = FeatureExtractor.from_model_name(
                     self.pretrained_feats_model,
@@ -1539,7 +1549,7 @@ def collate_sequence_padding(batch):
     # add boolean mask that signifies whether tokens are padded or not (such that they can be ignored later)
     pad_mask = torch.zeros((len(batch), n_max_len), dtype=torch.bool)
     for i, n_pad in enumerate(n_pads):
-        pad_mask[i, n_max_len - n_pad:] = True
+        pad_mask[i, n_max_len - n_pad :] = True
 
     batch_new["padding_mask"] = pad_mask.bool()
     return batch_new

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -1118,7 +1118,6 @@ class CTCData(Dataset):
             # build features
             if self.features in ("pretrained_feats", "pretrained_feats_aug"):
                 from trackastra_pretrained_feats import FeatureExtractor, WRPretrainedFeatures
-                import torch
                 device = "cuda" if torch.cuda.is_available() else "cpu"
                 feature_extractor = FeatureExtractor.from_model_name(
                     self.pretrained_feats_model,

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -180,8 +180,13 @@ class CTCData(Dataset):
         self.detection_folders = detection_folders
         self.ndim = ndim
         self.features = features
+        self.pretrained_feats_model = kwargs.get("pretrained_feats_model", None)
+        self.pretrained_feats_mode = kwargs.get("pretrained_feats_mode", "mean_patches_exact")
+        self.pretrained_feats_additional_props = kwargs.get("pretrained_feats_additional_props", None)
 
-        if features not in ("none", "wrfeat") and features not in _PROPERTIES[ndim]:
+        if features not in (
+            "none", "wrfeat", "pretrained_feats", "pretrained_feats_aug"
+        ) and features not in _PROPERTIES[ndim]:
             raise ValueError(
                 f"'{features}' not one of the supported {ndim}D features"
                 f" {tuple(_PROPERTIES[ndim].keys())}"
@@ -225,7 +230,7 @@ class CTCData(Dataset):
 
         start = default_timer()
 
-        if self.features == "wrfeat":
+        if self.features in ("wrfeat", "pretrained_feats", "pretrained_feats_aug"):
             self.windows = self._load_wrfeat()
         else:
             self.windows = self._load()
@@ -295,7 +300,7 @@ class CTCData(Dataset):
 
         start = default_timer()
 
-        if self.features == "wrfeat":
+        if self.features in ("wrfeat", "pretrained_feats", "pretrained_feats_aug"):
             self.windows = self._load_wrfeat()
         else:
             self.windows = self._load()
@@ -343,7 +348,7 @@ class CTCData(Dataset):
             default_augmenter,
         )
 
-        if self.features == "wrfeat":
+        if self.features in ("wrfeat", "pretrained_feats", "pretrained_feats_aug"):
             return self._setup_features_augs_wrfeat(ndim, features, augment, crop_size)
 
         cropper = (
@@ -517,7 +522,7 @@ class CTCData(Dataset):
             tifffile.imread(f).astype(dtype)
             for f in tqdm(
                 sorted(folder.glob("*.tif"))[
-                    self.start_frame : self.end_frame : self.downscale_temporal
+                    self.start_frame: self.end_frame: self.downscale_temporal
                 ],
                 leave=False,
                 desc=f"Loading [{self.start_frame}:{self.end_frame}]",
@@ -774,7 +779,8 @@ class CTCData(Dataset):
                         f" {det_folder}:{t1}"
                     )
 
-                # build matrix from incomplete labels, but full lineage graph. If a label is missing, I should skip over it.
+                # build matrix from incomplete labels, but full lineage graph.
+                # If a label is missing, I should skip over it.
                 A = _ctc_assoc_matrix(
                     _labels,
                     _ts,
@@ -808,7 +814,7 @@ class CTCData(Dataset):
 
     def __getitem__(self, n: int, return_dense=None):
         # if not set, use default
-        if self.features == "wrfeat":
+        if self.features in ("wrfeat", "pretrained_feats", "pretrained_feats_aug"):
             return self._getitem_wrfeat(n, return_dense)
 
         if return_dense is None:
@@ -1042,6 +1048,7 @@ class CTCData(Dataset):
         self.gt_masks = self._check_dimensions(self.gt_masks)
 
         # Load images
+        raw_imgs = None
         if self.img_folder is None:
             if self.gt_masks is not None:
                 self.imgs = np.zeros_like(self.gt_masks)
@@ -1050,10 +1057,12 @@ class CTCData(Dataset):
         else:
             logger.info("Loading images")
             imgs = self._load_tiffs(self.img_folder, dtype=np.float32)
+            raw_imgs = np.stack(list(imgs))  # keep raw for pretrained feature extractor
             self.imgs = np.stack([
-                normalize(_x) for _x in tqdm(imgs, desc="Normalizing", leave=False)
+                normalize(_x) for _x in tqdm(raw_imgs, desc="Normalizing", leave=False)
             ])
             self.imgs = self._check_dimensions(self.imgs)
+            raw_imgs = self._check_dimensions(raw_imgs)
             if self.compress:
                 # prepare images to be compressed later (e.g. removing non masked parts for regionprops features)
                 self.imgs = np.stack([
@@ -1107,13 +1116,37 @@ class CTCData(Dataset):
             self.det_masks[_f] = det_masks
 
             # build features
-
-            features = joblib.Parallel(n_jobs=8)(
-                joblib.delayed(wrfeat.WRFeatures.from_mask_img)(
-                    mask=mask[None], img=img[None], t_start=t
+            if self.features in ("pretrained_feats", "pretrained_feats_aug"):
+                from trackastra_pretrained_feats import FeatureExtractor, WRPretrainedFeatures
+                import torch
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+                feature_extractor = FeatureExtractor.from_model_name(
+                    self.pretrained_feats_model,
+                    self.imgs.shape[-2:],
+                    save_path=self.root / "embeddings",
+                    mode=self.pretrained_feats_mode,
+                    device=device,
+                    additional_features=self.pretrained_feats_additional_props,
                 )
-                for t, (mask, img) in enumerate(zip(det_masks, self.imgs))
-            )
+                imgs_for_extractor = raw_imgs if raw_imgs is not None else self.imgs
+                feature_extractor.precompute_image_embeddings(imgs_for_extractor)
+                features = [
+                    WRPretrainedFeatures.from_mask_img(
+                        img=img[None],
+                        mask=mask[None],
+                        feature_extractor=feature_extractor,
+                        t_start=t,
+                        additional_properties=feature_extractor.additional_features,
+                    )
+                    for t, (mask, img) in enumerate(zip(det_masks, self.imgs))
+                ]
+            else:
+                features = joblib.Parallel(n_jobs=8)(
+                    joblib.delayed(wrfeat.WRFeatures.from_mask_img)(
+                        mask=mask[None], img=img[None], t_start=t
+                    )
+                    for t, (mask, img) in enumerate(zip(det_masks, self.imgs))
+                )
 
             properties_by_time = dict()
             for _t, _feats in enumerate(features):
@@ -1162,7 +1195,8 @@ class CTCData(Dataset):
                 A = np.zeros((0, 0), dtype=bool)
                 coords = np.zeros((0, feat.ndim), dtype=int)
             else:
-                # build matrix from incomplete labels, but full lineage graph. If a label is missing, I should skip over it.
+                # build matrix from incomplete labels, but full lineage graph.
+                # If a label is missing, I should skip over it.
                 A = _ctc_assoc_matrix(
                     labels,
                     timepoints,
@@ -1229,6 +1263,9 @@ class CTCData(Dataset):
         coords0 = torch.from_numpy(coords0).float()
         assoc_matrix = torch.from_numpy(assoc_matrix.astype(np.float32))
         features = torch.from_numpy(feat.features_stacked).float()
+        pretrained_feats = feat.pretrained_feats
+        if pretrained_feats is not None:
+            pretrained_feats = torch.from_numpy(pretrained_feats).float()
         labels = torch.from_numpy(feat.labels).long()
         timepoints = torch.from_numpy(feat.timepoints).long()
 
@@ -1240,6 +1277,8 @@ class CTCData(Dataset):
             coords0 = coords0[:n_elems]
             features = features[:n_elems]
             assoc_matrix = assoc_matrix[:n_elems, :n_elems]
+            if pretrained_feats is not None:
+                pretrained_feats = pretrained_feats[:n_elems]
             logger.debug(
                 f"Clipped window of size {timepoints[n_elems - 1] - timepoints.min()}"
             )
@@ -1251,6 +1290,7 @@ class CTCData(Dataset):
             coords = coords0.clone()
         res = dict(
             features=features,
+            pretrained_feats=pretrained_feats,
             coords0=coords0,
             coords=coords,
             assoc_matrix=assoc_matrix,
@@ -1500,7 +1540,7 @@ def collate_sequence_padding(batch):
     # add boolean mask that signifies whether tokens are padded or not (such that they can be ignored later)
     pad_mask = torch.zeros((len(batch), n_max_len), dtype=torch.bool)
     for i, n_pad in enumerate(n_pads):
-        pad_mask[i, n_max_len - n_pad :] = True
+        pad_mask[i, n_max_len - n_pad:] = True
 
     batch_new["padding_mask"] = pad_mask.bool()
     return batch_new

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -93,6 +93,10 @@ class _CompressedArray:
         self._dtype = data.dtype.type
         self._shape = data.shape
 
+    @property
+    def shape(self):
+        return self._shape
+
     def decompress(self):
         s = lz4.frame.decompress(self._data)
         data = np.frombuffer(s, dtype=self._dtype).reshape(self._shape)
@@ -187,6 +191,8 @@ class CTCData(Dataset):
         self.pretrained_feats_additional_props = kwargs.get(
             "pretrained_feats_additional_props", None
         )
+        self.pretrained_n_augs = kwargs.get("pretrained_n_augs", 3)
+        self.rotate_features = kwargs.get("rotate_features", False)
 
         if (
             features
@@ -1005,7 +1011,7 @@ class CTCData(Dataset):
     def _setup_features_augs_wrfeat(
         self, ndim: int, features: str, augment: int, crop_size: tuple[int]
     ):
-        # FIXME: hardcoded
+        # FIXME: hardcoded for wrfeat; for pretrained_feats the actual dim depends on additional_props
         feat_dim = 7 if ndim == 2 else 12
         if augment == 1:
             augmenter = wrfeat.WRAugmentationPipeline([
@@ -1082,6 +1088,33 @@ class CTCData(Dataset):
         windows = []
         self.properties_by_time = dict()
         self.det_masks = dict()
+
+        # Build the pretrained feature extractor once, before the detection folder loop,
+        # so embeddings are not recomputed for each detection folder.
+        self.feature_extractor = None
+        WRPretrainedFeatures = None
+        if self.features in ("pretrained_feats", "pretrained_feats_aug"):
+            from trackastra_pretrained_feats import (
+                FeatureExtractor,
+                WRPretrainedFeatures,
+            )
+            if self.pretrained_n_augs != 3:
+                logger.warning(
+                    "pretrained_n_augs is not yet wired into FeatureExtractor"
+                    " - the value will be ignored."
+                )
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.feature_extractor = FeatureExtractor.from_model_name(
+                self.pretrained_feats_model,
+                self.imgs.shape[-2:],
+                save_path=self.root / "embeddings",
+                mode=self.pretrained_feats_mode,
+                device=device,
+                additional_features=self.pretrained_feats_additional_props,
+            )
+            imgs_for_extractor = raw_imgs if raw_imgs is not None else self.imgs
+            self.feature_extractor.precompute_image_embeddings(imgs_for_extractor)
+
         logger.info("Loading detections")
         for _f in self.detection_folders:
             det_folder = self.root / _f
@@ -1123,29 +1156,13 @@ class CTCData(Dataset):
 
             # build features
             if self.features in ("pretrained_feats", "pretrained_feats_aug"):
-                from trackastra_pretrained_feats import (
-                    FeatureExtractor,
-                    WRPretrainedFeatures,
-                )
-
-                device = "cuda" if torch.cuda.is_available() else "cpu"
-                feature_extractor = FeatureExtractor.from_model_name(
-                    self.pretrained_feats_model,
-                    self.imgs.shape[-2:],
-                    save_path=self.root / "embeddings",
-                    mode=self.pretrained_feats_mode,
-                    device=device,
-                    additional_features=self.pretrained_feats_additional_props,
-                )
-                imgs_for_extractor = raw_imgs if raw_imgs is not None else self.imgs
-                feature_extractor.precompute_image_embeddings(imgs_for_extractor)
                 features = [
                     WRPretrainedFeatures.from_mask_img(
                         img=img[None],
                         mask=mask[None],
-                        feature_extractor=feature_extractor,
+                        feature_extractor=self.feature_extractor,
                         t_start=t,
-                        additional_properties=feature_extractor.additional_features,
+                        additional_properties=self.feature_extractor.additional_features,
                     )
                     for t, (mask, img) in enumerate(zip(det_masks, self.imgs))
                 ]
@@ -1271,7 +1288,8 @@ class CTCData(Dataset):
         coords0 = np.concatenate((feat.timepoints[:, None], feat.coords), axis=-1)
         coords0 = torch.from_numpy(coords0).float()
         assoc_matrix = torch.from_numpy(assoc_matrix.astype(np.float32))
-        features = torch.from_numpy(feat.features_stacked).float()
+        stacked = feat.features_stacked
+        features = torch.from_numpy(stacked).float() if stacked is not None else torch.zeros(len(feat), 0)
         pretrained_feats = feat.pretrained_feats
         if pretrained_feats is not None:
             pretrained_feats = torch.from_numpy(pretrained_feats).float()
@@ -1291,6 +1309,11 @@ class CTCData(Dataset):
             logger.debug(
                 f"Clipped window of size {timepoints[n_elems - 1] - timepoints.min()}"
             )
+
+        if self.rotate_features and pretrained_feats is not None and self.feature_extractor is not None:
+            spatial_coords = coords0[:, 1:].numpy()
+            centroids = spatial_coords / np.array(self.imgs.shape[-2:], dtype=np.float32)
+            pretrained_feats = self.feature_extractor.apply_rot_to_features(pretrained_feats, centroids)
 
         if self.augmenter is not None:
             coords = coords0.clone()

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -530,18 +530,16 @@ class CTCData(Dataset):
         logger.debug(
             f"Temporal downscaling of {folder.name} by {self.downscale_temporal}"
         )
-        x = np.stack(
-            [
-                tifffile.imread(f).astype(dtype)
-                for f in tqdm(
-                    sorted(folder.glob("*.tif"))[
-                        self.start_frame : self.end_frame : self.downscale_temporal
-                    ],
-                    leave=False,
-                    desc=f"Loading [{self.start_frame}:{self.end_frame}]",
-                )
-            ]
-        )
+        x = np.stack([
+            tifffile.imread(f).astype(dtype)
+            for f in tqdm(
+                sorted(folder.glob("*.tif"))[
+                    self.start_frame : self.end_frame : self.downscale_temporal
+                ],
+                leave=False,
+                desc=f"Loading [{self.start_frame}:{self.end_frame}]",
+            )
+        ])
 
         # T, (Z), Y, X
         assert isinstance(self.downscale_spatial, int)
@@ -654,18 +652,16 @@ class CTCData(Dataset):
         else:
             logger.info("Loading images")
             imgs = self._load_tiffs(self.img_folder, dtype=np.float32)
-            self.imgs = np.stack(
-                [normalize(_x) for _x in tqdm(imgs, desc="Normalizing", leave=False)]
-            )
+            self.imgs = np.stack([
+                normalize(_x) for _x in tqdm(imgs, desc="Normalizing", leave=False)
+            ])
             self.imgs = self._check_dimensions(self.imgs)
             if self.compress:
                 # prepare images to be compressed later (e.g. removing non masked parts for regionprops features)
-                self.imgs = np.stack(
-                    [
-                        _compress_img_mask_preproc(im, mask, self.features)
-                        for im, mask in zip(self.imgs, self.gt_masks)
-                    ]
-                )
+                self.imgs = np.stack([
+                    _compress_img_mask_preproc(im, mask, self.features)
+                    for im, mask in zip(self.imgs, self.gt_masks)
+                ])
 
         assert len(self.gt_masks) == len(self.imgs)
 
@@ -1018,39 +1014,33 @@ class CTCData(Dataset):
         # FIXME: hardcoded for wrfeat; for pretrained_feats the actual dim depends on additional_props
         feat_dim = 7 if ndim == 2 else 12
         if augment == 1:
-            augmenter = wrfeat.WRAugmentationPipeline(
-                [
-                    wrfeat.WRRandomFlip(p=0.5),
-                    wrfeat.WRRandomAffine(
-                        p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
-                    ),
-                    # wrfeat.WRRandomBrightness(p=0.8, factor=(0.5, 2.0)),
-                    # wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
-                ]
-            )
+            augmenter = wrfeat.WRAugmentationPipeline([
+                wrfeat.WRRandomFlip(p=0.5),
+                wrfeat.WRRandomAffine(
+                    p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
+                ),
+                # wrfeat.WRRandomBrightness(p=0.8, factor=(0.5, 2.0)),
+                # wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
+            ])
         elif augment == 2:
-            augmenter = wrfeat.WRAugmentationPipeline(
-                [
-                    wrfeat.WRRandomFlip(p=0.5),
-                    wrfeat.WRRandomAffine(
-                        p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
-                    ),
-                    wrfeat.WRRandomBrightness(p=0.8),
-                    wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
-                ]
-            )
+            augmenter = wrfeat.WRAugmentationPipeline([
+                wrfeat.WRRandomFlip(p=0.5),
+                wrfeat.WRRandomAffine(
+                    p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
+                ),
+                wrfeat.WRRandomBrightness(p=0.8),
+                wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
+            ])
         elif augment == 3:
-            augmenter = wrfeat.WRAugmentationPipeline(
-                [
-                    wrfeat.WRRandomFlip(p=0.5),
-                    wrfeat.WRRandomAffine(
-                        p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
-                    ),
-                    wrfeat.WRRandomBrightness(p=0.8),
-                    wrfeat.WRRandomMovement(offset=(-10, 10), p=0.3),
-                    wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
-                ]
-            )
+            augmenter = wrfeat.WRAugmentationPipeline([
+                wrfeat.WRRandomFlip(p=0.5),
+                wrfeat.WRRandomAffine(
+                    p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
+                ),
+                wrfeat.WRRandomBrightness(p=0.8),
+                wrfeat.WRRandomMovement(offset=(-10, 10), p=0.3),
+                wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
+            ])
         else:
             augmenter = None
 
@@ -1080,22 +1070,17 @@ class CTCData(Dataset):
             logger.info("Loading images")
             imgs = self._load_tiffs(self.img_folder, dtype=np.float32)
             raw_imgs = np.stack(list(imgs))  # keep raw for pretrained feature extractor
-            self.imgs = np.stack(
-                [
-                    normalize(_x)
-                    for _x in tqdm(raw_imgs, desc="Normalizing", leave=False)
-                ]
-            )
+            self.imgs = np.stack([
+                normalize(_x) for _x in tqdm(raw_imgs, desc="Normalizing", leave=False)
+            ])
             self.imgs = self._check_dimensions(self.imgs)
             raw_imgs = self._check_dimensions(raw_imgs)
             if self.compress:
                 # prepare images to be compressed later (e.g. removing non masked parts for regionprops features)
-                self.imgs = np.stack(
-                    [
-                        _compress_img_mask_preproc(im, mask, self.features)
-                        for im, mask in zip(self.imgs, self.gt_masks)
-                    ]
-                )
+                self.imgs = np.stack([
+                    _compress_img_mask_preproc(im, mask, self.features)
+                    for im, mask in zip(self.imgs, self.gt_masks)
+                ])
 
         assert len(self.gt_masks) == len(self.imgs)
 

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -530,16 +530,18 @@ class CTCData(Dataset):
         logger.debug(
             f"Temporal downscaling of {folder.name} by {self.downscale_temporal}"
         )
-        x = np.stack([
-            tifffile.imread(f).astype(dtype)
-            for f in tqdm(
-                sorted(folder.glob("*.tif"))[
-                    self.start_frame : self.end_frame : self.downscale_temporal
-                ],
-                leave=False,
-                desc=f"Loading [{self.start_frame}:{self.end_frame}]",
-            )
-        ])
+        x = np.stack(
+            [
+                tifffile.imread(f).astype(dtype)
+                for f in tqdm(
+                    sorted(folder.glob("*.tif"))[
+                        self.start_frame : self.end_frame : self.downscale_temporal
+                    ],
+                    leave=False,
+                    desc=f"Loading [{self.start_frame}:{self.end_frame}]",
+                )
+            ]
+        )
 
         # T, (Z), Y, X
         assert isinstance(self.downscale_spatial, int)
@@ -652,16 +654,18 @@ class CTCData(Dataset):
         else:
             logger.info("Loading images")
             imgs = self._load_tiffs(self.img_folder, dtype=np.float32)
-            self.imgs = np.stack([
-                normalize(_x) for _x in tqdm(imgs, desc="Normalizing", leave=False)
-            ])
+            self.imgs = np.stack(
+                [normalize(_x) for _x in tqdm(imgs, desc="Normalizing", leave=False)]
+            )
             self.imgs = self._check_dimensions(self.imgs)
             if self.compress:
                 # prepare images to be compressed later (e.g. removing non masked parts for regionprops features)
-                self.imgs = np.stack([
-                    _compress_img_mask_preproc(im, mask, self.features)
-                    for im, mask in zip(self.imgs, self.gt_masks)
-                ])
+                self.imgs = np.stack(
+                    [
+                        _compress_img_mask_preproc(im, mask, self.features)
+                        for im, mask in zip(self.imgs, self.gt_masks)
+                    ]
+                )
 
         assert len(self.gt_masks) == len(self.imgs)
 
@@ -1014,33 +1018,39 @@ class CTCData(Dataset):
         # FIXME: hardcoded for wrfeat; for pretrained_feats the actual dim depends on additional_props
         feat_dim = 7 if ndim == 2 else 12
         if augment == 1:
-            augmenter = wrfeat.WRAugmentationPipeline([
-                wrfeat.WRRandomFlip(p=0.5),
-                wrfeat.WRRandomAffine(
-                    p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
-                ),
-                # wrfeat.WRRandomBrightness(p=0.8, factor=(0.5, 2.0)),
-                # wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
-            ])
+            augmenter = wrfeat.WRAugmentationPipeline(
+                [
+                    wrfeat.WRRandomFlip(p=0.5),
+                    wrfeat.WRRandomAffine(
+                        p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
+                    ),
+                    # wrfeat.WRRandomBrightness(p=0.8, factor=(0.5, 2.0)),
+                    # wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
+                ]
+            )
         elif augment == 2:
-            augmenter = wrfeat.WRAugmentationPipeline([
-                wrfeat.WRRandomFlip(p=0.5),
-                wrfeat.WRRandomAffine(
-                    p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
-                ),
-                wrfeat.WRRandomBrightness(p=0.8),
-                wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
-            ])
+            augmenter = wrfeat.WRAugmentationPipeline(
+                [
+                    wrfeat.WRRandomFlip(p=0.5),
+                    wrfeat.WRRandomAffine(
+                        p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
+                    ),
+                    wrfeat.WRRandomBrightness(p=0.8),
+                    wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
+                ]
+            )
         elif augment == 3:
-            augmenter = wrfeat.WRAugmentationPipeline([
-                wrfeat.WRRandomFlip(p=0.5),
-                wrfeat.WRRandomAffine(
-                    p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
-                ),
-                wrfeat.WRRandomBrightness(p=0.8),
-                wrfeat.WRRandomMovement(offset=(-10, 10), p=0.3),
-                wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
-            ])
+            augmenter = wrfeat.WRAugmentationPipeline(
+                [
+                    wrfeat.WRRandomFlip(p=0.5),
+                    wrfeat.WRRandomAffine(
+                        p=0.8, degrees=180, scale=(0.5, 2), shear=(0.1, 0.1)
+                    ),
+                    wrfeat.WRRandomBrightness(p=0.8),
+                    wrfeat.WRRandomMovement(offset=(-10, 10), p=0.3),
+                    wrfeat.WRRandomOffset(p=0.8, offset=(-3, 3)),
+                ]
+            )
         else:
             augmenter = None
 
@@ -1070,17 +1080,22 @@ class CTCData(Dataset):
             logger.info("Loading images")
             imgs = self._load_tiffs(self.img_folder, dtype=np.float32)
             raw_imgs = np.stack(list(imgs))  # keep raw for pretrained feature extractor
-            self.imgs = np.stack([
-                normalize(_x) for _x in tqdm(raw_imgs, desc="Normalizing", leave=False)
-            ])
+            self.imgs = np.stack(
+                [
+                    normalize(_x)
+                    for _x in tqdm(raw_imgs, desc="Normalizing", leave=False)
+                ]
+            )
             self.imgs = self._check_dimensions(self.imgs)
             raw_imgs = self._check_dimensions(raw_imgs)
             if self.compress:
                 # prepare images to be compressed later (e.g. removing non masked parts for regionprops features)
-                self.imgs = np.stack([
-                    _compress_img_mask_preproc(im, mask, self.features)
-                    for im, mask in zip(self.imgs, self.gt_masks)
-                ])
+                self.imgs = np.stack(
+                    [
+                        _compress_img_mask_preproc(im, mask, self.features)
+                        for im, mask in zip(self.imgs, self.gt_masks)
+                    ]
+                )
 
         assert len(self.gt_masks) == len(self.imgs)
 
@@ -1098,6 +1113,7 @@ class CTCData(Dataset):
                 FeatureExtractor,
                 WRPretrainedFeatures,
             )
+
             if self.pretrained_n_augs != 3:
                 logger.warning(
                     "pretrained_n_augs is not yet wired into FeatureExtractor"
@@ -1289,7 +1305,11 @@ class CTCData(Dataset):
         coords0 = torch.from_numpy(coords0).float()
         assoc_matrix = torch.from_numpy(assoc_matrix.astype(np.float32))
         stacked = feat.features_stacked
-        features = torch.from_numpy(stacked).float() if stacked is not None else torch.zeros(len(feat), 0)
+        features = (
+            torch.from_numpy(stacked).float()
+            if stacked is not None
+            else torch.zeros(len(feat), 0)
+        )
         pretrained_feats = feat.pretrained_feats
         if pretrained_feats is not None:
             pretrained_feats = torch.from_numpy(pretrained_feats).float()
@@ -1310,10 +1330,18 @@ class CTCData(Dataset):
                 f"Clipped window of size {timepoints[n_elems - 1] - timepoints.min()}"
             )
 
-        if self.rotate_features and pretrained_feats is not None and self.feature_extractor is not None:
+        if (
+            self.rotate_features
+            and pretrained_feats is not None
+            and self.feature_extractor is not None
+        ):
             spatial_coords = coords0[:, 1:].numpy()
-            centroids = spatial_coords / np.array(self.imgs.shape[-2:], dtype=np.float32)
-            pretrained_feats = self.feature_extractor.apply_rot_to_features(pretrained_feats, centroids)
+            centroids = spatial_coords / np.array(
+                self.imgs.shape[-2:], dtype=np.float32
+            )
+            pretrained_feats = self.feature_extractor.apply_rot_to_features(
+                pretrained_feats, centroids
+            )
 
         if self.augmenter is not None:
             coords = coords0.clone()

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -194,6 +194,7 @@ class CTCData(Dataset):
         )
         self.pretrained_n_augs = kwargs.get("pretrained_n_augs", 3)
         self.rotate_features = kwargs.get("rotate_features", False)
+        self.rotate_feature_axes = kwargs.get("rotate_feature_axes", "y")
 
         if (
             features
@@ -1353,7 +1354,7 @@ class CTCData(Dataset):
 
         if self.rotate_features and pretrained_feats is not None:
             pretrained_feats = rotate_features_by_coords(
-                pretrained_feats, coords, img.shape
+                pretrained_feats, coords, img.shape, axes=self.rotate_feature_axes
             )
 
         res = dict(
@@ -1560,7 +1561,10 @@ def pad_tensor(x, n_max: int, dim=0, value=0):
 
 
 def rotate_features_by_coords(
-    features: torch.Tensor, coords: torch.Tensor, image_shape: tuple[int, ...]
+    features: torch.Tensor,
+    coords: torch.Tensor,
+    image_shape: tuple[int, ...],
+    axes: Literal["y", "x", "both"] = "y",
 ) -> torch.Tensor:
     """Apply a RoPE-style rotation to each feature vector based on its spatial coordinates.
 
@@ -1573,6 +1577,11 @@ def rotate_features_by_coords(
             column is the timepoint.
         image_shape (tuple): Shape of the window images, whose last two entries are taken
             as (height, width) to normalize the coordinates with.
+        axes (str): Which spatial coordinates drive the rotation angle. "y" and "x" derive
+            a single angle from that coordinate alone, "both" alternates between the two
+            across feature pairs. Defaults to "y", which is what the released
+            general_2d_w_SAM2_features model was trained with, so that finetuning it sees
+            the feature distribution it expects.
 
     Returns:
         torch.Tensor: Rotated features of shape (n_objects, d).
@@ -1580,11 +1589,16 @@ def rotate_features_by_coords(
     n_objects, d = features.shape
     if d % 2 != 0:
         raise ValueError(f"Feature dimension must be even for rotation, got {d}")
+    if axes not in ("y", "x", "both"):
+        raise ValueError(f"axes must be one of 'y', 'x', 'both', got '{axes}'")
 
     extent = torch.tensor(image_shape[-2:], dtype=features.dtype)
     spatial_angles = 2 * math.pi * coords[:, 1:3].to(features.dtype) / extent
     n_pairs = d // 2
-    angles = spatial_angles.repeat(1, math.ceil(n_pairs / 2))[:, :n_pairs]
+    if axes == "both":
+        angles = spatial_angles.repeat(1, math.ceil(n_pairs / 2))[:, :n_pairs]
+    else:
+        angles = spatial_angles[:, 0 if axes == "y" else 1, None].expand(-1, n_pairs)
     cos, sin = torch.cos(angles), torch.sin(angles)
 
     pairs = features.view(n_objects, -1, 2)

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from collections import OrderedDict
 from collections.abc import Sequence
 from pathlib import Path
 from timeit import default_timer
@@ -1096,22 +1097,21 @@ class CTCData(Dataset):
         # so embeddings are not recomputed for each detection folder.
         self.feature_extractor = None
         self.pretrained_feat_dim = 0
+        self.aug_image_shapes = None
         WRPretrainedFeatures = None
+        # self.augmenter is None exactly when augment=0, which is how the data module marks
+        # the validation split. Augmented copies would make validation non deterministic.
+        use_augs = (
+            self.features == "pretrained_feats_aug"
+            and self.pretrained_n_augs > 0
+            and self.augmenter is not None
+        )
         if self.features in ("pretrained_feats", "pretrained_feats_aug"):
             from trackastra_pretrained_feats import (
                 FeatureExtractor,
                 WRPretrainedFeatures,
             )
 
-            if self.features == "pretrained_feats_aug" and self.pretrained_n_augs > 0:
-                logger.warning(
-                    "pretrained_n_augs is not wired into FeatureExtractor yet, so no"
-                    " augmented copies of the embeddings are generated."
-                    " FeatureExtractorAugWrapper in trackastra_pretrained_feats still"
-                    " imports trackastra.data.pretrained_augmentations and"
-                    " wrfeat.WRAugPretrainedFeatures, which do not exist in trackastra,"
-                    " so it cannot be used as is."
-                )
             device = "cuda" if torch.cuda.is_available() else "cpu"
             self.feature_extractor = FeatureExtractor.from_model_name(
                 self.pretrained_feats_model,
@@ -1122,8 +1122,11 @@ class CTCData(Dataset):
                 additional_features=self.pretrained_feats_additional_props,
             )
             self.pretrained_feat_dim = self.feature_extractor.hidden_state_size
-            imgs_for_extractor = raw_imgs if raw_imgs is not None else self.imgs
-            self.feature_extractor.precompute_image_embeddings(imgs_for_extractor)
+            if not use_augs:
+                # The augmented path recomputes embeddings per augmented copy itself.
+                imgs_for_extractor = raw_imgs if raw_imgs is not None else self.imgs
+                self.feature_extractor.precompute_image_embeddings(imgs_for_extractor)
+        raw_imgs_for_augs = raw_imgs if use_augs else None
         raw_imgs = None
 
         logger.info("Loading detections")
@@ -1166,7 +1169,15 @@ class CTCData(Dataset):
             self.det_masks[_f] = det_masks
 
             # build features
-            if self.features in ("pretrained_feats", "pretrained_feats_aug"):
+            if use_augs:
+                imgs_for_augs = (
+                    raw_imgs_for_augs if raw_imgs_for_augs is not None else self.imgs
+                )
+                features_per_aug = self._build_augmented_features(
+                    imgs_for_augs, det_masks
+                )
+                features = features_per_aug[0]
+            elif self.features in ("pretrained_feats", "pretrained_feats_aug"):
                 features = [
                     WRPretrainedFeatures.from_mask_img(
                         img=img[None],
@@ -1177,6 +1188,7 @@ class CTCData(Dataset):
                     )
                     for t, (mask, img) in enumerate(zip(det_masks, self.imgs))
                 ]
+                features_per_aug = [features]
             else:
                 features = joblib.Parallel(n_jobs=8)(
                     joblib.delayed(wrfeat.WRFeatures.from_mask_img)(
@@ -1184,6 +1196,7 @@ class CTCData(Dataset):
                     )
                     for t, (mask, img) in enumerate(zip(det_masks, self.imgs))
                 )
+                features_per_aug = [features]
 
             if self.features in ("pretrained_feats", "pretrained_feats_aug"):
                 # The shallow feature dim depends on pretrained_feats_additional_props,
@@ -1199,7 +1212,7 @@ class CTCData(Dataset):
             self.properties_by_time[_f] = properties_by_time
 
             _w = self._build_windows_wrfeat(
-                features,
+                features_per_aug,
                 det_masks,
                 det_gt_matching,
             )
@@ -1221,9 +1234,69 @@ class CTCData(Dataset):
 
         return windows
 
+    def _build_augmented_features(self, imgs: np.ndarray, det_masks: np.ndarray):
+        """Compute one set of per-timepoint features per augmented copy.
+
+        Returns a list of length pretrained_n_augs + 1, entry 0 being the unaugmented copy.
+        Detections that any copy lost, e.g. because augmentation moved them out of frame,
+        are dropped everywhere so that all copies share labels, timepoints and coords.
+        """
+        from trackastra_pretrained_feats.data.wrfeat import WRAugPretrainedFeatures
+        from trackastra_pretrained_feats.pretrained_augmentations import (
+            PretrainedAugmentations,
+        )
+        from trackastra_pretrained_feats.pretrained_features import (
+            FeatureExtractorAugWrapper,
+        )
+
+        wrapper = FeatureExtractorAugWrapper(
+            extractor=self.feature_extractor,
+            augmenter=PretrainedAugmentations(),
+            n_aug=self.pretrained_n_augs,
+        )
+        aug_dict = wrapper.compute_all_features(
+            torch.from_numpy(np.asarray(imgs)),
+            torch.from_numpy(np.asarray(det_masks).astype(np.int32)),
+        )
+        self.aug_image_shapes = wrapper.image_shape_reference
+
+        n_entries = self.pretrained_n_augs + 1
+        copies = [aug_dict[str(i)]["data"] for i in range(n_entries)]
+        # Keep only the detections that survived every augmentation
+        common = set.intersection(*[
+            {(t, lab) for t, per_t in copy.items() for lab in per_t} for copy in copies
+        ])
+
+        features_per_aug = []
+        for copy in copies:
+            per_timepoint = []
+            for t in sorted(copy):
+                labels = sorted(lab for lab in copy[t] if (t, lab) in common)
+                entries = [copy[t][lab] for lab in labels]
+                feats = OrderedDict()
+                for key in entries[0]["features"] if entries else ():
+                    feats[key] = np.stack([
+                        np.asarray(e["features"][key]) for e in entries
+                    ])
+                per_timepoint.append(
+                    WRAugPretrainedFeatures.from_window(
+                        features=feats,
+                        coords=np.stack([np.asarray(e["coords"]) for e in entries]),
+                        timepoints=np.full(len(entries), t, dtype=np.int32),
+                        labels=np.asarray(labels, dtype=np.int32),
+                    )
+                )
+            features_per_aug.append(per_timepoint)
+        n_total = sum(len(per_t) for per_t in copies[0].values())
+        logger.info(
+            f"Built {len(features_per_aug)} feature copies ({self.pretrained_n_augs}"
+            f" augmented), {len(common)} of {n_total} detections shared by all"
+        )
+        return features_per_aug
+
     def _build_windows_wrfeat(
         self,
-        features: Sequence[wrfeat.WRFeatures],
+        features_per_aug: Sequence[Sequence[wrfeat.WRFeatures]],
         det_masks: np.ndarray,
         matching: tuple[dict],
     ):
@@ -1241,7 +1314,11 @@ class CTCData(Dataset):
         ):
             img = self.imgs[t1:t2]
             mask = det_masks[t1:t2]
-            feat = wrfeat.WRFeatures.concat(features[t1:t2])
+            feats = [
+                wrfeat.WRFeatures.concat(per_aug[t1:t2]) for per_aug in features_per_aug
+            ]
+            # All copies share labels, timepoints and the association matrix
+            feat = feats[0]
 
             labels = feat.labels
             timepoints = feat.timepoints
@@ -1268,7 +1345,7 @@ class CTCData(Dataset):
                 assoc_matrix=A,
                 labels=labels,
                 timepoints=timepoints,
-                wrfeat=feat,
+                wrfeat=feats,
             )
             windows.append(w)
 
@@ -1289,7 +1366,11 @@ class CTCData(Dataset):
         mask = track["mask"]
         timepoints = track["timepoints"]
         # track["t1"]
-        feat = track["wrfeat"]
+        feats = track["wrfeat"]
+        # Draw one of the augmented copies. Index 0 is the unaugmented one, which is all
+        # there is unless pretrained_feats_aug generated more.
+        aug_choice = 0 if len(feats) == 1 else np.random.randint(len(feats))
+        feat = feats[aug_choice]
 
         if return_dense and isinstance(mask, _CompressedArray):
             mask = mask.decompress()
@@ -1353,8 +1434,13 @@ class CTCData(Dataset):
             coords = coords0.clone()
 
         if self.rotate_features and pretrained_feats is not None:
+            # Augmentation can resize the images, so normalize against the shape the
+            # chosen copy was extracted at rather than the original one.
+            image_shape = img.shape
+            if self.aug_image_shapes is not None:
+                image_shape = self.aug_image_shapes.get(aug_choice, image_shape)
             pretrained_feats = rotate_features_by_coords(
-                pretrained_feats, coords, img.shape, axes=self.rotate_feature_axes
+                pretrained_feats, coords, image_shape, axes=self.rotate_feature_axes
             )
 
         res = dict(

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -1209,8 +1209,14 @@ class CTCData(Dataset):
             # The extractor holds the pretrained backbone and its precomputed embeddings.
             # Neither is needed once the features are built, and keeping them around makes
             # the dataset unpicklable for the on-disk cache (see cache_class).
+            # Drop the embeddings before clear_model(), whose empty_cache() would otherwise
+            # still see them referenced, so their GPU memory is never handed back and the
+            # next dataset of a multi-sequence run runs out of memory.
+            self.feature_extractor.embeddings = None
             self.feature_extractor.clear_model()
             self.feature_extractor = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
         return windows
 

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -1582,14 +1582,15 @@ def rotate_features_by_coords(
         raise ValueError(f"Feature dimension must be even for rotation, got {d}")
 
     extent = torch.tensor(image_shape[-2:], dtype=features.dtype)
-    angles = 2 * math.pi * coords[:, 1:3].to(features.dtype) / extent
-    angles = angles.repeat(1, d // 2)
+    spatial_angles = 2 * math.pi * coords[:, 1:3].to(features.dtype) / extent
+    n_pairs = d // 2
+    angles = spatial_angles.repeat(1, math.ceil(n_pairs / 2))[:, :n_pairs]
     cos, sin = torch.cos(angles), torch.sin(angles)
 
     pairs = features.view(n_objects, -1, 2)
     x_feat, y_feat = pairs[..., 0], pairs[..., 1]
-    x_rot = x_feat * cos[:, ::2] - y_feat * sin[:, ::2]
-    y_rot = x_feat * sin[:, ::2] + y_feat * cos[:, ::2]
+    x_rot = x_feat * cos - y_feat * sin
+    y_rot = x_feat * sin + y_feat * cos
     return torch.stack([x_rot, y_rot], dim=-1).reshape(n_objects, d)
 
 

--- a/trackastra/data/data.py
+++ b/trackastra/data/data.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from collections.abc import Sequence
 from pathlib import Path
 from timeit import default_timer
@@ -1011,7 +1012,8 @@ class CTCData(Dataset):
     def _setup_features_augs_wrfeat(
         self, ndim: int, features: str, augment: int, crop_size: tuple[int]
     ):
-        # FIXME: hardcoded for wrfeat; for pretrained_feats the actual dim depends on additional_props
+        # FIXME: hardcoded. For pretrained_feats this is overwritten in _load_wrfeat, where
+        # the actual dim of the additional region props is known.
         feat_dim = 7 if ndim == 2 else 12
         if augment == 1:
             augmenter = wrfeat.WRAugmentationPipeline([
@@ -1092,6 +1094,7 @@ class CTCData(Dataset):
         # Build the pretrained feature extractor once, before the detection folder loop,
         # so embeddings are not recomputed for each detection folder.
         self.feature_extractor = None
+        self.pretrained_feat_dim = 0
         WRPretrainedFeatures = None
         if self.features in ("pretrained_feats", "pretrained_feats_aug"):
             from trackastra_pretrained_feats import (
@@ -1099,10 +1102,14 @@ class CTCData(Dataset):
                 WRPretrainedFeatures,
             )
 
-            if self.pretrained_n_augs != 3:
+            if self.features == "pretrained_feats_aug" and self.pretrained_n_augs > 0:
                 logger.warning(
-                    "pretrained_n_augs is not yet wired into FeatureExtractor"
-                    " - the value will be ignored."
+                    "pretrained_n_augs is not wired into FeatureExtractor yet, so no"
+                    " augmented copies of the embeddings are generated."
+                    " FeatureExtractorAugWrapper in trackastra_pretrained_feats still"
+                    " imports trackastra.data.pretrained_augmentations and"
+                    " wrfeat.WRAugPretrainedFeatures, which do not exist in trackastra,"
+                    " so it cannot be used as is."
                 )
             device = "cuda" if torch.cuda.is_available() else "cpu"
             self.feature_extractor = FeatureExtractor.from_model_name(
@@ -1113,8 +1120,10 @@ class CTCData(Dataset):
                 device=device,
                 additional_features=self.pretrained_feats_additional_props,
             )
+            self.pretrained_feat_dim = self.feature_extractor.hidden_state_size
             imgs_for_extractor = raw_imgs if raw_imgs is not None else self.imgs
             self.feature_extractor.precompute_image_embeddings(imgs_for_extractor)
+        raw_imgs = None
 
         logger.info("Loading detections")
         for _f in self.detection_folders:
@@ -1175,6 +1184,12 @@ class CTCData(Dataset):
                     for t, (mask, img) in enumerate(zip(det_masks, self.imgs))
                 )
 
+            if self.features in ("pretrained_feats", "pretrained_feats_aug"):
+                # The shallow feature dim depends on pretrained_feats_additional_props,
+                # so read it off the features that were actually built.
+                stacked = features[0].features_stacked
+                self.feat_dim = 0 if stacked is None else stacked.shape[-1]
+
             properties_by_time = dict()
             for _t, _feats in enumerate(features):
                 properties_by_time[_t] = dict(
@@ -1189,6 +1204,13 @@ class CTCData(Dataset):
             )
 
             windows.extend(_w)
+
+        if self.feature_extractor is not None:
+            # The extractor holds the pretrained backbone and its precomputed embeddings.
+            # Neither is needed once the features are built, and keeping them around makes
+            # the dataset unpicklable for the on-disk cache (see cache_class).
+            self.feature_extractor.clear_model()
+            self.feature_extractor = None
 
         return windows
 
@@ -1297,7 +1319,9 @@ class CTCData(Dataset):
         )
         pretrained_feats = feat.pretrained_feats
         if pretrained_feats is not None:
-            pretrained_feats = torch.from_numpy(pretrained_feats).float()
+            # WRPretrainedFeatures stores these as a torch tensor, but WRFeatures.concat
+            # turns them into an array, so accept either.
+            pretrained_feats = torch.as_tensor(pretrained_feats).float()
         labels = torch.from_numpy(feat.labels).long()
         timepoints = torch.from_numpy(feat.timepoints).long()
 
@@ -1315,24 +1339,17 @@ class CTCData(Dataset):
                 f"Clipped window of size {timepoints[n_elems - 1] - timepoints.min()}"
             )
 
-        if (
-            self.rotate_features
-            and pretrained_feats is not None
-            and self.feature_extractor is not None
-        ):
-            spatial_coords = coords0[:, 1:].numpy()
-            centroids = spatial_coords / np.array(
-                self.imgs.shape[-2:], dtype=np.float32
-            )
-            pretrained_feats = self.feature_extractor.apply_rot_to_features(
-                pretrained_feats, centroids
-            )
-
         if self.augmenter is not None:
             coords = coords0.clone()
             coords[:, 1:] += torch.randint(0, 512, (1, self.ndim))
         else:
             coords = coords0.clone()
+
+        if self.rotate_features and pretrained_feats is not None:
+            pretrained_feats = rotate_features_by_coords(
+                pretrained_feats, coords, img.shape
+            )
+
         res = dict(
             features=features,
             pretrained_feats=pretrained_feats,
@@ -1534,6 +1551,40 @@ def pad_tensor(x, n_max: int, dim=0, value=0):
     # pad = torch.full(pad_shape, fill_value=value, dtype=x.dtype).to(x.device)
     pad = torch.full(pad_shape, fill_value=value, dtype=x.dtype)
     return torch.cat((x, pad), dim=dim)
+
+
+def rotate_features_by_coords(
+    features: torch.Tensor, coords: torch.Tensor, image_shape: tuple[int, ...]
+) -> torch.Tensor:
+    """Apply a RoPE-style rotation to each feature vector based on its spatial coordinates.
+
+    Disambiguates the pretrained features of nearby detections, which are otherwise nearly
+    identical for patch-pooled embeddings, and mitigates overfitting.
+
+    Args:
+        features (torch.Tensor): Features of shape (n_objects, d). d must be even.
+        coords (torch.Tensor): Coordinates of shape (n_objects, 1 + ndim), where the first
+            column is the timepoint.
+        image_shape (tuple): Shape of the window images, whose last two entries are taken
+            as (height, width) to normalize the coordinates with.
+
+    Returns:
+        torch.Tensor: Rotated features of shape (n_objects, d).
+    """
+    n_objects, d = features.shape
+    if d % 2 != 0:
+        raise ValueError(f"Feature dimension must be even for rotation, got {d}")
+
+    extent = torch.tensor(image_shape[-2:], dtype=features.dtype)
+    angles = 2 * math.pi * coords[:, 1:3].to(features.dtype) / extent
+    angles = angles.repeat(1, d // 2)
+    cos, sin = torch.cos(angles), torch.sin(angles)
+
+    pairs = features.view(n_objects, -1, 2)
+    x_feat, y_feat = pairs[..., 0], pairs[..., 1]
+    x_rot = x_feat * cos[:, ::2] - y_feat * sin[:, ::2]
+    y_rot = x_feat * sin[:, ::2] + y_feat * cos[:, ::2]
+    return torch.stack([x_rot, y_rot], dim=-1).reshape(n_objects, d)
 
 
 def collate_sequence_padding(batch):

--- a/trackastra/data/wrfeat.py
+++ b/trackastra/data/wrfeat.py
@@ -403,6 +403,7 @@ def _transform_affine(k: str, v: np.ndarray, M: np.ndarray):
         "intensity_max",
         "intensity_min",
         "border_dist",
+        "pretrained_feats",
     ):
         pass
     else:
@@ -434,7 +435,7 @@ class WRRandomAffine(WRBaseAugmentation):
         )
 
         # M is by default 3D , we need to remove the last dimension for 2D
-        self._M = self._M[-features.ndim :, -features.ndim :]
+        self._M = self._M[-features.ndim:, -features.ndim:]
         points = features.coords @ self._M.T
 
         feats = OrderedDict(

--- a/trackastra/data/wrfeat.py
+++ b/trackastra/data/wrfeat.py
@@ -435,7 +435,7 @@ class WRRandomAffine(WRBaseAugmentation):
         )
 
         # M is by default 3D , we need to remove the last dimension for 2D
-        self._M = self._M[-features.ndim:, -features.ndim:]
+        self._M = self._M[-features.ndim :, -features.ndim :]
         points = features.coords @ self._M.T
 
         feats = OrderedDict(

--- a/trackastra/data/wrfeat.py
+++ b/trackastra/data/wrfeat.py
@@ -7,7 +7,7 @@ import logging
 from collections import OrderedDict
 from collections.abc import Iterable, Sequence
 from functools import reduce
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, ClassVar, Literal, Optional
 
 import joblib
 import numpy as np
@@ -114,6 +114,16 @@ def _border_dist_fast(mask: np.ndarray, cutoff: float = 5):
 
 class WRFeatures:
     """regionprops features for a windowed track region."""
+
+    # Stacked feature dim per property set and number of spatial dimensions. Used to size
+    # the model input before any data is loaded, and looked up by
+    # trackastra_pretrained_feats to size its additional region props.
+    # regionprops_small is not in _PROPERTIES, it is defined by trackastra_pretrained_feats.
+    PROPERTIES_DIMS: ClassVar = {
+        "regionprops": {2: 8, 3: 13},
+        "regionprops2": {2: 7, 3: 12},
+        "regionprops_small": {2: 5, 3: 10},
+    }
 
     def __init__(
         self,

--- a/trackastra/model/__init__.py
+++ b/trackastra/model/__init__.py
@@ -1,5 +1,3 @@
-# ruff: noqa: F401
-
 import os
 
 from .model import TrackingTransformer

--- a/trackastra/tracking/__init__.py
+++ b/trackastra/tracking/__init__.py
@@ -1,5 +1,3 @@
-# ruff: noqa: F401
-
 from .track_graph import TrackGraph
 from .tracking import (
     build_graph,

--- a/trackastra/utils/__init__.py
+++ b/trackastra/utils/__init__.py
@@ -1,5 +1,3 @@
-# ruff: noqa: F401
-
 from .utils import (
     blockwise_causal_norm,
     blockwise_sum,

--- a/trackastra/utils/utils.py
+++ b/trackastra/utils/utils.py
@@ -112,7 +112,7 @@ def render_label(
             im_img = img[..., :4]
             if img.shape[-1] < 4:
                 im_img = np.concatenate(
-                    [img, np.ones(img.shape[:2] + (4 - img.shape[-1],))], axis=-1
+                    [img, np.ones((*img.shape[:2], 4 - img.shape[-1]))], axis=-1
                 )
         else:
             raise ValueError("img should be 2 or 3 dimensional")
@@ -378,15 +378,13 @@ def preallocate_memory(dataset, model_lightning, batch_size, max_tokens, device)
         batch = dict(
             features=batched(
                 torch.zeros(
-                    (max_len,) + x["features"].shape[1:], dtype=x["features"].dtype
+                    (max_len, *x["features"].shape[1:]), dtype=x["features"].dtype
                 ),
                 batch_size,
                 device,
             ),
             coords=batched(
-                torch.zeros(
-                    (max_len,) + x["coords"].shape[1:], dtype=x["coords"].dtype
-                ),
+                torch.zeros((max_len, *x["coords"].shape[1:]), dtype=x["coords"].dtype),
                 batch_size,
                 device,
             ),

--- a/trackastra/utils/utils.py
+++ b/trackastra/utils/utils.py
@@ -398,6 +398,15 @@ def preallocate_memory(dataset, model_lightning, batch_size, max_tokens, device)
             ),
             padding_mask=batched(torch.zeros(max_len, dtype=bool), batch_size, device),
         )
+        if x.get("pretrained_feats") is not None:
+            batch["pretrained_feats"] = batched(
+                torch.zeros(
+                    (max_len, *x["pretrained_feats"].shape[1:]),
+                    dtype=x["pretrained_feats"].dtype,
+                ),
+                batch_size,
+                device,
+            )
 
     loss = model_lightning._common_step(batch)["loss"]
     loss.backward()


### PR DESCRIPTION
Hi @C-Achard,

Here's are my minimal changes to make training work with SAM2 features.

Let me know how it looks!

PS. In case it helps, here's my yaml config file to train `trackastra`:

<details>
<summary>yaml config</summary>

    # Trackastra finetuning config file for TOIAM dataset (using SAM2 features)
    # Run: python /mnt/vast-nhr/home/archit/u12090/trackastra/scripts/train.py -c train_config.yaml
    
    name: toiam_sam2_features
    outdir: ./runs
    
    # Data
    ndim: 2
    input_train:
      - /mnt/vast-nhr/projects/cidas/cca/data/toiam/data/00
      - /mnt/vast-nhr/projects/cidas/cca/data/toiam/data/01
    input_val:
      - /mnt/vast-nhr/projects/cidas/cca/data/toiam/data/04
    detection_folders:
      - TRA
      - SEG
    
    # Feature backbone (aligned to pretrained model)
    features: pretrained_feats_aug
    pretrained_feats_model: facebook/sam2.1-hiera-base-plus
    pretrained_feats_mode: mean_patches_exact
    pretrained_feats_additional_props: regionprops_small
    pretrained_n_augs: 15
    reduced_pretrained_feat_dim: 128
    rotate_features: true
    
    # Finetuning from pretrained
    model: /user/archit/u12090/.local/share/trackastra/models/general_2d_w_SAM2_features
    
    # Model architecture (matching pretrained)
    d_model: 256
    num_encoder_layers: 4
    num_decoder_layers: 4
    dropout: 0.05
    window: 4
    attn_dist_mode: v1
    causal_norm: none
    
    # Training hyperparameters
    epochs: 500
    warmup_epochs: 5
    train_samples: 32000
    batch_size: 16
    max_tokens: 2048
    weight_decay: 0.01
    weight_by_dataset: true
    
    # Augmentation
    crop_size:
      - 320
      - 320
    
    # Caching
    cachedir: ./runs/.cache
    
    # Logging and other misc. stuff
    logger: tensorboard
    seed: 42
    
</details>