### PR TITLE
Make motile v1.0 core dependency

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -65,10 +65,6 @@ jobs:
           channels: conda-forge
           channel-priority: true
 
-      - name: Install ilp dependencies
-        if: matrix.ilp == 'true'
-        run: mamba install -c gurobi -c funkelab ilpy
-
       - name: Install package with core dependencies
         run: python -m pip install -e .[test]
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -24,7 +24,7 @@ jobs:
         run: pipx run pre-commit run --all-files
         
   test-core:
-    name: Core Tests - ${{ matrix.platform }} py${{ matrix.python-version }} ilp=${{ matrix.ilp }} sam2=${{ matrix.sam2 }}
+    name: Core Tests - ${{ matrix.platform }} py${{ matrix.python-version }} sam2=${{ matrix.sam2 }}
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
@@ -34,24 +34,16 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         platform: [ubuntu-latest]
-        ilp: ["false"]
         sam2: ["false"]
         include:
           - platform: windows-latest
             python-version: "3.10"
-            ilp: "false"
             sam2: "false"
           - platform: macos-latest
             python-version: "3.10"
-            ilp: "false"
-            sam2: "false"
-          - platform: ubuntu-latest
-            python-version: "3.10"
-            ilp: "true"
             sam2: "false"
           - platform: macos-latest
             python-version: "3.12"
-            ilp: "false"
             sam2: "true"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pip install -e "./trackastra[all]"
 <details>
 <summary>📄 <h4></b>Notes/Troubleshooting</h4></summary>
   
-- For ILP-based linking (`mode="ilp"`), Trackastra uses [`motile`](https://funkelab.github.io/motile/index.html), which is installed automatically with two discrete optimizers: the free [SCIP Optimizer](https://www.scipopt.org/) and the [Gurobi Optimizer](https://www.gurobi.com/). If a valid Gurobi license is found, it will be used automatically; otherwise motile falls back to SCIP. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
+- For ILP-based linking (`mode="ilp"`), Trackastra uses [`motile`](https://funkelab.github.io/motile/index.html), which is installed automatically with the free [SCIP Optimizer](https://www.scipopt.org/). To optionally use the [Gurobi Optimizer](https://www.gurobi.com/) instead, install with `pip install motile[gurobi]`. If a valid Gurobi license is found, it will be used automatically. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
 - 2024-06-07: On Apple M3 chips, you might have to use the nightly build of `torch` and `torchvision`, or worst case build them yourself.
   
 </details>

--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ Trackastra can then be installed from PyPI using `pip`:
 pip install trackastra
 ```
 
-### With ILP support
-For tracking with an integer linear program (ILP, which is optional)
-```bash
-pip install "trackastra[ilp]"
-```
-
 ### 🆕😎 With pretrained features
 
 For our [new model variant](https://github.com/C-Achard/Trackastra-et-Ultra) that uses SAM2 features for improved tracking performance on certain data, for example for tracking bacteria:
@@ -78,7 +72,7 @@ pip install -e "./trackastra[all]"
 <details>
 <summary>📄 <h4></b>Notes/Troubleshooting</h4></summary>
   
-- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html) with two discrete optimizers: the free [SCIP Optimizer](https://www.scipopt.org/) and the [Gurobi Optimizer](https://www.gurobi.com/). If a valid Gurobi license is found, it will be used automatically; otherwise motile falls back to SCIP. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
+- For ILP-based linking (`mode="ilp"`), Trackastra uses [`motile`](https://funkelab.github.io/motile/index.html), which is installed automatically with two discrete optimizers: the free [SCIP Optimizer](https://www.scipopt.org/) and the [Gurobi Optimizer](https://www.gurobi.com/). If a valid Gurobi license is found, it will be used automatically; otherwise motile falls back to SCIP. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
 - 2024-06-07: On Apple M3 chips, you might have to use the nightly build of `torch` and `torchvision`, or worst case build them yourself.
   
 </details>
@@ -111,7 +105,7 @@ The predicted associations can then be used for linking with several modes:
 
 - `greedy_nodiv` (greedy linking with no division) - fast, no additional dependencies
 - `greedy` (greedy linking with division) - fast, no additional dependencies
-- `ilp` (ILP based linking) - slower but more accurate, needs [`motile`](https://github.com/funkelab/motile)
+- `ilp` (ILP based linking) - slower but more accurate, uses [`motile`](https://github.com/funkelab/motile)
 
 Apart from that, no hyperparameters to choose :)
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ pip install trackastra
 ### With ILP support
 For tracking with an integer linear program (ILP, which is optional)
 ```bash
-conda create --name trackastra python=3.10 --no-default-packages
-conda activate trackastra
-conda install -c conda-forge -c gurobi -c funkelab ilpy
 pip install "trackastra[ilp]"
 ```
 
@@ -73,9 +70,6 @@ pip install "trackastra[train]"
 <summary>📄 <h4>Development installation</h4></summary>
   
 ```bash
-conda create --name trackastra python=3.10 --no-default-packages
-conda activate trackastra
-conda install -c conda-forge -c gurobi -c funkelab ilpy
 git clone https://github.com/weigertlab/trackastra.git
 pip install -e "./trackastra[all]"
 ```
@@ -84,12 +78,7 @@ pip install -e "./trackastra[all]"
 <details>
 <summary>📄 <h4></b>Notes/Troubleshooting</h4></summary>
   
-- For the optional ILP linking, this will install [`motile`](https://funkelab.github.io/motile/index.html) and binaries for two discrete optimizers:
-
-  1. The [Gurobi Optimizer](https://www.gurobi.com/). This is a commercial solver, which requires a valid license. Academic licenses are provided for free, see [here](https://www.gurobi.com/academia/academic-program-and-licenses/) for how to obtain one.
-
-  2. The [SCIP Optimizer](https://www.scipopt.org/), a free and open source solver. If `motile` does not find a valid Gurobi license, it will fall back to using SCIP.
-- On MacOS, installing packages into the conda environment before installing `ilpy` can cause problems.
+- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html), which includes the [SCIP Optimizer](https://www.scipopt.org/), a free and open source discrete optimizer. To optionally use the [Gurobi Optimizer](https://www.gurobi.com/) instead, install with `pip install motile[gurobi]`. Gurobi requires a valid license (free academic licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/)).
 - 2024-06-07: On Apple M3 chips, you might have to use the nightly build of `torch` and `torchvision`, or worst case build them yourself.
   
 </details>

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install -e "./trackastra[all]"
 <details>
 <summary>📄 <h4></b>Notes/Troubleshooting</h4></summary>
   
-- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html), which includes the [SCIP Optimizer](https://www.scipopt.org/), a free and open source discrete optimizer. To optionally use the [Gurobi Optimizer](https://www.gurobi.com/) instead, install with `pip install motile[gurobi]`. Gurobi requires a valid license (free academic licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/)).
+- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html) with two discrete optimizers: the free [SCIP Optimizer](https://www.scipopt.org/) and the [Gurobi Optimizer](https://www.gurobi.com/). If a valid Gurobi license is found, it will be used automatically; otherwise motile falls back to SCIP. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
 - 2024-06-07: On Apple M3 chips, you might have to use the nightly build of `torch` and `torchvision`, or worst case build them yourself.
   
 </details>

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,13 +39,12 @@ install_requires =
     requests
     psutil
     platformdirs
+    motile[gurobi] >= 1.0
     # zarr>=3  # Will need a python 3.11+ version
 python_requires = >=3.10
 include_package_data = True
 
 [options.extras_require]
-ilp =
-    motile[gurobi] >= 1.0
 dev =
     pytest
     ruff
@@ -64,7 +63,7 @@ train =
     kornia>=0.7.0
     gitpython
 all =
-    trackastra[train,ilp,dev]
+    trackastra[train,dev]
 test =
     pytest
 etultra =

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     psutil
     platformdirs
     motile >= 1.0
+    ilpy >= 0.6
     # zarr>=3  # Will need a python 3.11+ version
 python_requires = >=3.10
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     requests
     psutil
     platformdirs
-    motile[gurobi] >= 1.0
+    motile >= 1.0
     # zarr>=3  # Will need a python 3.11+ version
 python_requires = >=3.10
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ include_package_data = True
 
 [options.extras_require]
 ilp =
-    motile >= 1.0
+    motile[gurobi] >= 1.0
 dev =
     pytest
     ruff

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     psutil
     platformdirs
     motile >= 1.0
-    ilpy >= 0.6
+    ilpy >= 0.6  # can be removed once funkelab/motile#164 is released
     # zarr>=3  # Will need a python 3.11+ version
 python_requires = >=3.10
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ include_package_data = True
 
 [options.extras_require]
 ilp =
-    motile >= 0.3
+    motile >= 1.0
 dev =
     pytest
     ruff

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     psutil
     platformdirs
     motile >= 1.0
-    ilpy >= 0.6  # can be removed once funkelab/motile#164 is released
+    ilpy >= 0.6  # can be removed once motile pins ilpy[gurobi] >= 0.6
     # zarr>=3  # Will need a python 3.11+ version
 python_requires = >=3.10
 include_package_data = True

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -13,13 +13,6 @@ from trackastra.tracking import graph_to_ctc, graph_to_napari_tracks, write_to_g
 # Mark all tests in this module as core/inference tests
 pytestmark = pytest.mark.core
 
-try:
-    import motile  # noqa: F401
-
-    ILP_TESTS = True
-except ModuleNotFoundError:
-    ILP_TESTS = False
-
 
 @pytest.mark.parametrize(
     "example_data",
@@ -125,7 +118,6 @@ def test_empty_window_greedy():
     )
 
 
-@pytest.mark.skipif(not ILP_TESTS, reason="Package for ILP tracking not installed")
 def test_empty_window_ilp():
     imgs, masks = example_data_hela()
 
@@ -153,7 +145,6 @@ def test_empty_sequence_greedy():
     )
 
 
-@pytest.mark.skipif(not ILP_TESTS, reason="Package for ILP tracking not installed")
 def test_empty_sequence_ilp():
     imgs = np.zeros((10, 100, 100), dtype=float)
     masks = np.zeros((10, 100, 100), dtype=int)

--- a/trackastra/cli.py
+++ b/trackastra/cli.py
@@ -63,10 +63,7 @@ def cli():
         "--mode",
         choices=["greedy_nodiv", "greedy", "ilp"],
         default="greedy",
-        help=(
-            "Mode for candidate graph pruning. For installing the ilp tracker, see"
-            " https://github.com/weigertlab/trackastra#installation."
-        ),
+        help="Mode for candidate graph pruning.",
     )
     p_track.add_argument(
         "--max-distance",

--- a/trackastra/tracking/ilp.py
+++ b/trackastra/tracking/ilp.py
@@ -109,29 +109,33 @@ def solve_full_ilp(
 
     # NODES
     solver.add_cost(
-        motile.costs.NodeSelection(weight=p.nodeW, constant=p.nodeC, attribute="weight")
+        motile.costs.NodeSelectedCost(
+            weight=p.nodeW, constant=p.nodeC, attribute="weight"
+        )
     )
     used_costs.nodeW = p.nodeW
     used_costs.nodeC = p.nodeC
 
     # EDGES
     solver.add_cost(
-        motile.costs.EdgeSelection(weight=p.edgeW, constant=p.edgeC, attribute="weight")
+        motile.costs.EdgeSelectedCost(
+            weight=p.edgeW, constant=p.edgeC, attribute="weight"
+        )
     )
     used_costs.edgeW = p.edgeW
     used_costs.edgeC = p.edgeC
 
     # APPEAR
-    solver.add_cost(motile.costs.Appear(constant=p.appearC))
+    solver.add_cost(motile.costs.NodeAppearCost(constant=p.appearC))
     used_costs.appearC = p.appearC
 
     # DISAPPEAR
-    solver.add_cost(motile.costs.Disappear(constant=p.disappearC))
+    solver.add_cost(motile.costs.NodeDisappearCost(constant=p.disappearC))
     used_costs.disappearC = p.disappearC
 
     # DIVISION
     if allow_divisions:
-        solver.add_cost(motile.costs.Split(constant=p.splitC))
+        solver.add_cost(motile.costs.NodeSplitCost(constant=p.splitC))
         used_costs.splitC = p.splitC
 
     # Add constraints

--- a/trackastra/tracking/ilp.py
+++ b/trackastra/tracking/ilp.py
@@ -9,8 +9,8 @@ try:
     import motile
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "For tracking with an ILP, please conda install the optional `motile`"
-        " dependency following https://funkelab.github.io/motile/install.html."
+        "For tracking with an ILP, please install the optional `motile`"
+        ' dependency with `pip install "trackastra[ilp]"`.'
     )
 
 

--- a/trackastra/tracking/ilp.py
+++ b/trackastra/tracking/ilp.py
@@ -2,17 +2,9 @@ import logging
 import time
 from types import SimpleNamespace
 
+import motile
 import networkx as nx
 import yaml
-
-try:
-    import motile
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        "For tracking with an ILP, please install the optional `motile`"
-        ' dependency with `pip install "trackastra[ilp]"`.'
-    )
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Update trackastra for motile 1.0 compatibility and make motile a regular dependency.

- Update all motile cost class names to match the motile 1.0 API (`NodeSelection` → `NodeSelectedCost`, `EdgeSelection` → `EdgeSelectedCost`, `Appear` → `NodeAppearCost`, `Disappear` → `NodeDisappearCost`, `Split` → `NodeSplitCost`)
- Make `motile >= 1.0` a regular dependency (no longer an optional `[ilp]` extra) — motile now installs cleanly via pip
- Pin `ilpy >= 0.6` to ensure the Gurobi/SCIP fallback fix (funkelab/ilpy#75) is always available
- Simplify installation instructions in README — remove conda/ilpy install steps, remove `[ilp]` install section, remove outdated MacOS conda caveat
- Remove try/except guard and outdated error message in `ilp.py`
- Remove `ILP_TESTS` skipif gating in tests (motile is always installed)
- Remove outdated ILP install hint from CLI `--mode` help text
- Clean up CI: remove conda ilpy install step and `ilp` matrix variable

Fixes https://forum.image.sc/t/error-with-trackastra-napari-using-ilp/121872
Closes #45

## Test plan
- [x] Reproduced the `AttributeError: module 'motile.costs' has no attribute 'NodeSelection'` with motile 1.0.0
- [x] Verified fix resolves the error
- [x] All 9 tests pass in a fresh environment with motile 1.0.0 + ilpy 0.6.0 (including ILP tests)

## Follow-ups
- funkelab/motile#164 — pin `ilpy[gurobi] >= 0.6` in motile (after which the explicit ilpy pin here can be dropped)
- weigertlab/napari-trackastra#13 — remove motile-as-optional references from napari-trackastra