### PR TITLE
Update motile API for v1.0 compatibility

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -65,12 +65,13 @@ jobs:
           channels: conda-forge
           channel-priority: true
 
-      - name: Install ilp dependencies
-        if: matrix.ilp == 'true'
-        run: mamba install -c gurobi -c funkelab ilpy
-
       - name: Install package with core dependencies
+        if: matrix.ilp != 'true'
         run: python -m pip install -e .[test]
+
+      - name: Install package with ILP dependencies
+        if: matrix.ilp == 'true'
+        run: python -m pip install -e .[ilp,test]
 
       - name: Install additional dependencies for SAM2 features tests
         if: matrix.sam2 == 'true'

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install -e "./trackastra[all]"
 <details>
 <summary>📄 <h4></b>Notes/Troubleshooting</h4></summary>
   
-- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html) with the free [SCIP Optimizer](https://www.scipopt.org/). To optionally use the [Gurobi Optimizer](https://www.gurobi.com/) instead, install with `pip install motile[gurobi]`. If a valid Gurobi license is found, it will be used automatically. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
+- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html) with two discrete optimizers: the free [SCIP Optimizer](https://www.scipopt.org/) and the [Gurobi Optimizer](https://www.gurobi.com/). If a valid Gurobi license is found, it will be used automatically; otherwise motile falls back to SCIP. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
 - 2024-06-07: On Apple M3 chips, you might have to use the nightly build of `torch` and `torchvision`, or worst case build them yourself.
   
 </details>

--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ pip install trackastra
 ### With ILP support
 For tracking with an integer linear program (ILP, which is optional)
 ```bash
-conda create --name trackastra python=3.10 --no-default-packages
-conda activate trackastra
-conda install -c conda-forge -c gurobi -c funkelab ilpy
 pip install "trackastra[ilp]"
 ```
 
@@ -73,9 +70,6 @@ pip install "trackastra[train]"
 <summary>📄 <h4>Development installation</h4></summary>
   
 ```bash
-conda create --name trackastra python=3.10 --no-default-packages
-conda activate trackastra
-conda install -c conda-forge -c gurobi -c funkelab ilpy
 git clone https://github.com/weigertlab/trackastra.git
 pip install -e "./trackastra[all]"
 ```
@@ -84,12 +78,7 @@ pip install -e "./trackastra[all]"
 <details>
 <summary>📄 <h4></b>Notes/Troubleshooting</h4></summary>
   
-- For the optional ILP linking, this will install [`motile`](https://funkelab.github.io/motile/index.html) and binaries for two discrete optimizers:
-
-  1. The [Gurobi Optimizer](https://www.gurobi.com/). This is a commercial solver, which requires a valid license. Academic licenses are provided for free, see [here](https://www.gurobi.com/academia/academic-program-and-licenses/) for how to obtain one.
-
-  2. The [SCIP Optimizer](https://www.scipopt.org/), a free and open source solver. If `motile` does not find a valid Gurobi license, it will fall back to using SCIP.
-- On MacOS, installing packages into the conda environment before installing `ilpy` can cause problems.
+- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html) with the free [SCIP Optimizer](https://www.scipopt.org/). To optionally use the [Gurobi Optimizer](https://www.gurobi.com/) instead, install with `pip install motile[gurobi]`. If a valid Gurobi license is found, it will be used automatically. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
 - 2024-06-07: On Apple M3 chips, you might have to use the nightly build of `torch` and `torchvision`, or worst case build them yourself.
   
 </details>

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ include_package_data = True
 
 [options.extras_require]
 ilp =
-    motile >= 1.0
+    motile[gurobi] >= 1.0
     ilpy >= 0.6  # can be removed once motile pins ilpy[gurobi] >= 0.6
 dev =
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,8 @@ include_package_data = True
 
 [options.extras_require]
 ilp =
-    motile >= 0.3
+    motile >= 1.0
+    ilpy >= 0.6  # can be removed once motile pins ilpy[gurobi] >= 0.6
 dev =
     pytest
     ruff

--- a/trackastra/tracking/ilp.py
+++ b/trackastra/tracking/ilp.py
@@ -9,8 +9,8 @@ try:
     import motile
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "For tracking with an ILP, please conda install the optional `motile`"
-        " dependency following https://funkelab.github.io/motile/install.html."
+        "For tracking with an ILP, please install the optional `motile`"
+        ' dependency with `pip install "trackastra[ilp]"`.'
     )
 
 
@@ -109,29 +109,33 @@ def solve_full_ilp(
 
     # NODES
     solver.add_cost(
-        motile.costs.NodeSelection(weight=p.nodeW, constant=p.nodeC, attribute="weight")
+        motile.costs.NodeSelectedCost(
+            weight=p.nodeW, constant=p.nodeC, attribute="weight"
+        )
     )
     used_costs.nodeW = p.nodeW
     used_costs.nodeC = p.nodeC
 
     # EDGES
     solver.add_cost(
-        motile.costs.EdgeSelection(weight=p.edgeW, constant=p.edgeC, attribute="weight")
+        motile.costs.EdgeSelectedCost(
+            weight=p.edgeW, constant=p.edgeC, attribute="weight"
+        )
     )
     used_costs.edgeW = p.edgeW
     used_costs.edgeC = p.edgeC
 
     # APPEAR
-    solver.add_cost(motile.costs.Appear(constant=p.appearC))
+    solver.add_cost(motile.costs.NodeAppearCost(constant=p.appearC))
     used_costs.appearC = p.appearC
 
     # DISAPPEAR
-    solver.add_cost(motile.costs.Disappear(constant=p.disappearC))
+    solver.add_cost(motile.costs.NodeDisappearCost(constant=p.disappearC))
     used_costs.disappearC = p.disappearC
 
     # DIVISION
     if allow_divisions:
-        solver.add_cost(motile.costs.Split(constant=p.splitC))
+        solver.add_cost(motile.costs.NodeSplitCost(constant=p.splitC))
         used_costs.splitC = p.splitC
 
     # Add constraints


### PR DESCRIPTION
## Summary

Update trackastra for motile 1.0 compatibility, keeping motile as an optional `[ilp]` dependency.

- Update all motile cost class names to match the motile 1.0 API (`NodeSelection` → `NodeSelectedCost`, `EdgeSelection` → `EdgeSelectedCost`, `Appear` → `NodeAppearCost`, `Disappear` → `NodeDisappearCost`, `Split` → `NodeSplitCost`)
- Pin `motile >= 1.0` and `ilpy >= 0.6` in the `[ilp]` extra
- Simplify ILP install instructions — `pip install "trackastra[ilp]"` is all that's needed now, no more conda
- Update CI to `pip install .[ilp,test]` instead of `mamba install ilpy`
- Update error message in `ilp.py` to point to pip install

Fixes https://forum.image.sc/t/error-with-trackastra-napari-using-ilp/121872
Closes #45