### PR TITLE
Make motile v1 a core dependency

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -24,7 +24,7 @@ jobs:
         run: pipx run pre-commit run --all-files
         
   test-core:
-    name: Core Tests - ${{ matrix.platform }} py${{ matrix.python-version }} ilp=${{ matrix.ilp }} sam2=${{ matrix.sam2 }}
+    name: Core Tests - ${{ matrix.platform }} py${{ matrix.python-version }} sam2=${{ matrix.sam2 }}
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
@@ -34,24 +34,16 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         platform: [ubuntu-latest]
-        ilp: ["false"]
         sam2: ["false"]
         include:
           - platform: windows-latest
             python-version: "3.10"
-            ilp: "false"
             sam2: "false"
           - platform: macos-latest
             python-version: "3.10"
-            ilp: "false"
-            sam2: "false"
-          - platform: ubuntu-latest
-            python-version: "3.10"
-            ilp: "true"
             sam2: "false"
           - platform: macos-latest
             python-version: "3.12"
-            ilp: "false"
             sam2: "true"
 
     steps:
@@ -66,12 +58,7 @@ jobs:
           channel-priority: true
 
       - name: Install package with core dependencies
-        if: matrix.ilp != 'true'
         run: python -m pip install -e .[test]
-
-      - name: Install package with ILP dependencies
-        if: matrix.ilp == 'true'
-        run: python -m pip install -e .[ilp,test]
 
       - name: Install additional dependencies for SAM2 features tests
         if: matrix.sam2 == 'true'

--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ Trackastra can then be installed from PyPI using `pip`:
 pip install trackastra
 ```
 
-### With ILP support
-For tracking with an integer linear program (ILP, which is optional)
-```bash
-pip install "trackastra[ilp]"
-```
-
 ### 🆕😎 With pretrained features
 
 For our [new model variant](https://github.com/C-Achard/Trackastra-et-Ultra) that uses SAM2 features for improved tracking performance on certain data, for example for tracking bacteria:
@@ -78,7 +72,7 @@ pip install -e "./trackastra[all]"
 <details>
 <summary>📄 <h4></b>Notes/Troubleshooting</h4></summary>
   
-- For the optional ILP linking, `pip install "trackastra[ilp]"` will install [`motile`](https://funkelab.github.io/motile/index.html) with two discrete optimizers: the free [SCIP Optimizer](https://www.scipopt.org/) and the [Gurobi Optimizer](https://www.gurobi.com/). If a valid Gurobi license is found, it will be used automatically; otherwise motile falls back to SCIP. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
+- For ILP-based linking (`mode="ilp"`), Trackastra uses [`motile`](https://funkelab.github.io/motile/index.html) with two discrete optimizers: the free [SCIP Optimizer](https://www.scipopt.org/) and the [Gurobi Optimizer](https://www.gurobi.com/). If a valid Gurobi license is found, it will be used automatically; otherwise motile falls back to SCIP. Free academic Gurobi licenses are available [here](https://www.gurobi.com/academia/academic-program-and-licenses/).
 - 2024-06-07: On Apple M3 chips, you might have to use the nightly build of `torch` and `torchvision`, or worst case build them yourself.
   
 </details>
@@ -111,7 +105,7 @@ The predicted associations can then be used for linking with several modes:
 
 - `greedy_nodiv` (greedy linking with no division) - fast, no additional dependencies
 - `greedy` (greedy linking with division) - fast, no additional dependencies
-- `ilp` (ILP based linking) - slower but more accurate, needs [`motile`](https://github.com/funkelab/motile)
+- `ilp` (ILP based linking) - slower but more accurate, uses [`motile`](https://github.com/funkelab/motile)
 
 Apart from that, no hyperparameters to choose :)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,14 +39,13 @@ install_requires =
     requests
     psutil
     platformdirs
+    motile[gurobi] >= 1.0
+    ilpy >= 0.6  # can be removed once motile pins ilpy[gurobi] >= 0.6
     # zarr>=3  # Will need a python 3.11+ version
 python_requires = >=3.10
 include_package_data = True
 
 [options.extras_require]
-ilp =
-    motile[gurobi] >= 1.0
-    ilpy >= 0.6  # can be removed once motile pins ilpy[gurobi] >= 0.6
 dev =
     pytest
     ruff
@@ -64,7 +63,7 @@ train =
     kornia>=0.7.0
     gitpython
 all =
-    trackastra[train,ilp,dev]
+    trackastra[train,dev]
 test =
     pytest
 etultra =

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -13,13 +13,6 @@ from trackastra.tracking import graph_to_ctc, graph_to_napari_tracks, write_to_g
 # Mark all tests in this module as core/inference tests
 pytestmark = pytest.mark.core
 
-try:
-    import motile  # noqa: F401
-
-    ILP_TESTS = True
-except ModuleNotFoundError:
-    ILP_TESTS = False
-
 
 @pytest.mark.parametrize(
     "example_data",
@@ -125,7 +118,6 @@ def test_empty_window_greedy():
     )
 
 
-@pytest.mark.skipif(not ILP_TESTS, reason="Package for ILP tracking not installed")
 def test_empty_window_ilp():
     imgs, masks = example_data_hela()
 
@@ -153,7 +145,6 @@ def test_empty_sequence_greedy():
     )
 
 
-@pytest.mark.skipif(not ILP_TESTS, reason="Package for ILP tracking not installed")
 def test_empty_sequence_ilp():
     imgs = np.zeros((10, 100, 100), dtype=float)
     masks = np.zeros((10, 100, 100), dtype=int)

--- a/trackastra/cli.py
+++ b/trackastra/cli.py
@@ -63,10 +63,7 @@ def cli():
         "--mode",
         choices=["greedy_nodiv", "greedy", "ilp"],
         default="greedy",
-        help=(
-            "Mode for candidate graph pruning. For installing the ilp tracker, see"
-            " https://github.com/weigertlab/trackastra#installation."
-        ),
+        help="Mode for candidate graph pruning.",
     )
     p_track.add_argument(
         "--max-distance",

--- a/trackastra/tracking/ilp.py
+++ b/trackastra/tracking/ilp.py
@@ -2,17 +2,9 @@ import logging
 import time
 from types import SimpleNamespace
 
+import motile
 import networkx as nx
 import yaml
-
-try:
-    import motile
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        "For tracking with an ILP, please install the optional `motile`"
-        ' dependency with `pip install "trackastra[ilp]"`.'
-    )
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Follow-up to #65. Make `motile[gurobi]` a regular dependency — motile 1.0 installs cleanly via pip, and `ilpy >= 0.6` ensures correct Gurobi→SCIP fallback when no full license is available.

- Move `motile[gurobi]` and `ilpy` from `[ilp]` extra to `install_requires`, remove `[ilp]` extra
- Remove try/except guard in `ilp.py`
- Remove `[ilp]` install section from README
- Remove `ILP_TESTS` skipif gating in tests
- Remove outdated ILP install hint from CLI `--mode` help
- Remove `ilp` matrix variable from CI

## Test plan
- [x] All 9 tests pass locally in a fresh env (Python 3.12, motile 1.0.0, ilpy 0.6.0, gurobipy 13.0.2)
- [x] ILP tests correctly use Gurobi→SCIP fallback (no full Gurobi license needed)