### PR TITLE
docs: document conda install and training co-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Trackastra can then be installed from PyPI using `pip`:
 ```bash
 pip install trackastra
 ```
+or from [conda-forge](https://anaconda.org/conda-forge/trackastra):
+```bash
+conda install -c conda-forge trackastra
+```
 
 ### 🆕😎 With pretrained features
 
@@ -58,6 +62,10 @@ and select the `general_2d_w_SAM2_features` pre-trained model for predictions, p
 ### Installation with training support
 ```bash
 pip install "trackastra[train]"
+```
+The conda-forge package [ships the core/inference dependencies only](https://github.com/conda-forge/trackastra-feedstock/pull/9), so with conda install the training dependencies alongside it:
+```bash
+conda install -c conda-forge trackastra lightning wandb tensorboard configargparse matplotlib kornia gitpython
 ```
 
 <details>


### PR DESCRIPTION
## What

Documents installing Trackastra via **conda** in the README.

- Adds a `conda install -c conda-forge trackastra` line next to the existing `pip install trackastra`.
- Next to `pip install "trackastra[train]"`, notes that the conda-forge package is core-only ([feedstock#9](https://github.com/conda-forge/trackastra-feedstock/pull/9)) and gives the training-dependency co-install one-liner.

## Why

[conda-forge/trackastra-feedstock#9](https://github.com/conda-forge/trackastra-feedstock/pull/9) switches the conda package to ship the core/inference dependencies only (the `train` extras — `lightning`, `wandb`, `tensorboard`, `configargparse`, `matplotlib`, `kornia`, `gitpython` — are dropped from the hard `run` deps). The README previously documented only `pip`. Conda has no equivalent of pip's `trackastra[train]` extra, so the training deps are documented as a co-install. Docs-only change.

## Verification

- Confirmed every package in the co-install command is available on conda-forge (incl. `kornia` ≥0.7, `matplotlib`), and `trackastra` itself is published there.
- The dropped deps are all under `setup.cfg [options.extras_require] train`, not `install_requires`.
